### PR TITLE
Add support for readonly editor

### DIFF
--- a/html/interactive-guides/editor.html
+++ b/html/interactive-guides/editor.html
@@ -13,23 +13,23 @@
         <span class="editorFileName"></span>
     </div>
     <div class="editorButtonFrame" role="group" aria-label="editor buttons">
-        <button type="button" class="editorSaveButton" aria-label="Save">
+        <button type="button" class="editorSaveButton btn" aria-label="Save">
             <span class="glyphicon glyphicon-save-file"></span>
             <span>Save</span>
         </button>
-        <button type="button" class="editorResetButton" aria-label="Reset">
+        <button type="button" class="editorResetButton btn" aria-label="Reset">
             <span class="glyphicon glyphicon-repeat"></span>
             <span>Reset</span>
         </button>
-        <button type="button" class="editorUndoButton" aria-label="Undo">
+        <button type="button" class="editorUndoButton btn" aria-label="Undo">
             <span class="glyphicon glyphicon-arrow-left"></span>
             <span>Undo</span>
         </button>
-        <button type="button" class="editorRedoButton" aria-label="Redo">
+        <button type="button" class="editorRedoButton btn" aria-label="Redo">
             <span class="glyphicon glyphicon-arrow-right"></span>
             <span>Redo</span>
         </button>
-        <button type="button" class="editorRunButton" aria-label="Run">
+        <button type="button" class="editorRunButton btn" aria-label="Run">
             <span class="glyphicon glyphicon-save-file"></span>
             <span>Run</span>
         </button>


### PR DESCRIPTION
With the new support, the json to support readonly editor is
{
                "displayType": "tabbedEditor",
                "editorList": [
                  {
                    "displayType":"fileEditor",
                    "fileName": "music-download.java",
                    "preload": [
                          "import org.eclipse.microprofile.config.Config;",
                          "import org.eclipse.microprofile.config.inject.ConfigProperty;",
                          "",
                          "public class music-download {",
                          "",
                          "@Config config",
                          "@ConfigProperty(name=\"download-url\", defaultValue=\"ftp://music.com/us/download\")",
                          "private String downloadUrl;",
                          "",
                          "}"
                    ],
                    "readonly": true,
                    "save": false
                  }

With readonly editor, the buttons are grey out too.