### PR TITLE
Improve tabID of tabbed editor tabs

### DIFF
--- a/js/interactive-guides/modules/tabbed-editor.js
+++ b/js/interactive-guides/modules/tabbed-editor.js
@@ -87,7 +87,7 @@ var tabbedEditor = (function() {
             }
 
             // Create the dom elements for the new editor
-            var editorName = 'teTab-editor' + this.displayTypeNum + '-tab' + numTabs;    // or should this be the filename?
+            var editorName = 'teTab-' + this.stepName + '-editor' + this.displayTypeNum + '-tab' + numTabs;
 
             // Tab....
             var $tabItem = $("<li role='presentation'><a role='tab' href='#" + editorName + "' aria-label='" + editorInfo.fileName + "'>" + editorInfo.fileName + "</a></li>");


### PR DESCRIPTION
fixes #56 

In a tabbed editor, update the id of the content div containing the file editor of the tab to include the stepname.  Without adding the stepname we get inconsistent behavior when more than one step of a guide has a tabbed editor.