### PR TITLE
Update tabs to fill width of tabbed editor better

### DIFF
--- a/css/interactive-guides/tabbed-editor.css
+++ b/css/interactive-guides/tabbed-editor.css
@@ -11,15 +11,16 @@
  .teContainer>.nav-tabs>li>a {
     text-overflow: ellipsis;
     overflow: hidden;
-    white-space: nowrap;   
+    white-space: nowrap;
+    text-align: center;   
+    padding: 5px 3px;          /* Minimize Bootstrap's padding for tabs              */
+    border: 1px solid #ddd;  /* Give a border to all tabs so they are recognizable */
+    margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
 }
 
 /* Half screen editor tab formatting. Maximize the space taken up in the tabs so the filename will be shown */
 .subContainerDiv.col-sm-6 > .teContainer>.nav-tabs>li>a {
-    font-size: 0.75vw;
-    padding: 5px 3px;          /* Minimize Bootstrap's padding for tabs              */
-    border: 1px solid #ddd;  /* Give a border to all tabs so they are recognizable */
-    margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
+    font-size: 0.85vw;
 }
 
 @media all and (max-width:768px)
@@ -27,9 +28,6 @@
     /* Always shrink the padding and margins in mobile view even if the subcontainer is 12 columns wide since mobile is much smaller */
     .teContainer>.nav-tabs>li>a {
         font-size: 2.5vw !important; /* Override the font-size from non-mobile view */
-        padding: 5px 3px;          /* Minimize Bootstrap's padding for tabs              */
-        border: 1px solid #ddd;  /* Give a border to all tabs so they are recognizable */
-        margin-right: 0;           /* Overlay bootstrap's margin so tabs are condensed   */
     }
 }
 
@@ -43,6 +41,9 @@
 
 .teTabContent div.editorButtonFrame {
     border-top: none;
+    border-left-color: #ddd;    /* Change the border color of the menu bar in */
+    border-right-color: #ddd;   /* the editor to soften the transition from   */ 
+    border-bottom-color: #aaa;  /* the tabs to the editor frame.              */
 }
 
 .teContents {

--- a/js/interactive-guides/modules/tabbed-editor.js
+++ b/js/interactive-guides/modules/tabbed-editor.js
@@ -100,7 +100,7 @@ var tabbedEditor = (function() {
             var editorName = 'teTab-' + this.stepName + '-editor' + this.displayTypeNum + '-tab' + numTabs;
 
             // Tab....
-            var $tabItem = $("<li role='presentation' style='max-width: " + this.tabSize + ";'><a role='tab' href='#" + editorName + "' aria-label='" + editorInfo.fileName + "' title='" + editorInfo.fileName + "' >" + editorInfo.fileName + "</a></li>");
+            var $tabItem = $("<li role='presentation' style='" + this.cssWidthValue + ": " + this.tabSize + ";'><a role='tab' href='#" + editorName + "' aria-label='" + editorInfo.fileName + "' title='" + editorInfo.fileName + "' >" + editorInfo.fileName + "</a></li>");
             var thisTabbedEditor = this;
             $tabItem.on('click', 'a', function(e){
                 // Prevent the anchor's default click action
@@ -117,7 +117,7 @@ var tabbedEditor = (function() {
                         activeTabChanged = true;
                         // Make the old tab inactive.
                         thisTabbedEditor.$active.removeClass('active');   // <a> element
-                        thisTabbedEditor.$active.parent().css('max-width', thisTabbedEditor.tabSize );  // <li> element
+                        thisTabbedEditor.$active.parent().css(thisTabbedEditor.cssWidthValue, thisTabbedEditor.tabSize );  // <li> element
                     } else {
                         // User clicked currently active tab.  No need to switch anything.
                         return;
@@ -135,7 +135,7 @@ var tabbedEditor = (function() {
 
                 // Make the new tab active.
                 thisTabbedEditor.$active.addClass('active');     // <a> element
-                thisTabbedEditor.$active.parent().css('max-width', thisTabbedEditor.activeTabSize);  // <li> element
+                thisTabbedEditor.$active.parent().css(thisTabbedEditor.cssWidthValue, thisTabbedEditor.activeTabSize);  // <li> element
                 thisTabbedEditor.$content.show();
 
                 if (activeTabChanged && thisTabbedEditor.activeTabChangeCallback) {
@@ -290,19 +290,17 @@ var tabbedEditor = (function() {
             // Determine the width of the tabs based on the bootstrapColSize
             // that the tabbed editor is given.
             var numNonActiveEditors = editors.length - 1;
-            if (numNonActiveEditors <= 0) {     
+            if (numNonActiveEditors <= 0  ||  
+                content.bootstrapColSize === "col-sm-12") {     
                 numNonActiveEditors = 1; // To avoid division by zero, and to give future tabs added a size.
                 thisTabbedEditor.activeTabSize = '100%';
+                thisTabbedEditor.cssWidthValue = "max-width";   // Display full name of active editor 
+                                                                // when we have the room!
             } else {
                 thisTabbedEditor.activeTabSize = '50%';
+                thisTabbedEditor.cssWidthValue = "width";
             }
-            if (content.bootstrapColSize === "col-sm-12") {
-                // full page width tabbed editor
-                thisTabbedEditor.tabSize = Math.floor(100/numNonActiveEditors) + '%';
-            } else {
-                // 1/2 page width tabbed editor 
-                thisTabbedEditor.tabSize = Math.floor(50/numNonActiveEditors) + '%';                
-            }
+            thisTabbedEditor.tabSize = Math.floor(50/numNonActiveEditors) + '%';                
 
             if (editors.length > 0) {
                 for (var i=0; i<editors.length; i++) {


### PR DESCRIPTION
Fixes for 

- Fix the Tabbed Editor so that if there are more than one tabs then the tabs will stretch the whole way across the page.
-  Center the text in the tabs
-  Improve the appearance of the tabs to the editor......either make the left/right borders of the editor menu bar light grey as with the tabs and maybe put a black border under the editor menu bar to close off the editor block