### PR TITLE
Update to Related guides title

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -32,7 +32,7 @@ var blueprint = (function(){
             if (relateGuides.length > 0) {
               var relateGuidesStep = {
                 "name": "RelateGuides",
-                "title": "Relate Guides",
+                "title": "Related guides",
                 "description": ["<div id=\"relateGuidesContent\"/>"]
               };
               steps.push(relateGuidesStep);


### PR DESCRIPTION
Changing the title from 'Relate Guide' to 'Related guides' to match the title in the design redline.