### PR TITLE
Update to responsive font size of filenames in tabbedEditor

### DIFF
--- a/css/interactive-guides/tabbed-editor.css
+++ b/css/interactive-guides/tabbed-editor.css
@@ -20,18 +20,32 @@
 
 /* Half screen editor tab formatting. Maximize the space taken up in the tabs so the filename will be shown */
 .subContainerDiv.col-sm-6 > .teContainer>.nav-tabs>li>a {
-    font-size: 0.85vw;
+    /* Move font between 10-14px when the browser width is between 768px     */
+    /* and 1170px.  After this point the width of the guide row is constant. */
+    font-size: calc(.70em + 4 * (100vw - 768px) / 402);
+    font-size: -webkit-calc(70% + 4 * (100vw - 768px) / 402);
 }
 
-@media all and (max-width:768px)
+@media only screen and (max-width:768px)
 {
-    /* Always shrink the padding and margins in mobile view even if the subcontainer is 12 columns wide since mobile is much smaller */
+    /* In single column output, allow the font to adjust to maximize the amount of filename shown */
     .teContainer>.nav-tabs>li>a {
-        font-size: 2.5vw !important; /* Override the font-size from non-mobile view */
+        font-size: calc(.70em + 4 * (100vw - 320px) / 447) !important;
+        font-size: -webkit-calc(70% + 4 * (100vw - 320px) / 447) !important;
     }
 }
 
- .teContainer>.nav-tabs>li>a.active {
+@media only screen and (min-width:1170px)
+{
+    .teContainer>.nav-tabs>li>a {
+        /* The guide TOC and right side info has a max width of 1170px.  */
+        /* Further increases in the browser width should not change the  */
+        /* font size of the filenames in the tabs.                       */
+        font-size: 14px !important;
+    }
+}
+
+.teContainer>.nav-tabs>li>a.active {
     background-color: #eee;
 }
 


### PR DESCRIPTION
I updated the font-size in the css to be a new formula instead of just .85vw for desktop and 2.5vw for smaller screens.

The font-size is now determined as follows:

- For small screens (up to 768px):
font-size: calc(.70em + 4 * (100vw - 320px) / 447)

- For desktop screens (768px - 1170px): 
font-size: calc(.70em + 4 * (100vw - 768px) / 402)

- For screens over 1170px:
font-size: 14px

To explain....
When size is determined using viewport units (vw or vh)  it is given a percentage of the browser width or height.     
1vw = 1% of the browser width
100 vw = 100% of the browser width
The viewport units are automatically recalculated whenever the the viewport (browser window size) changes.  However, we were having a problem with the size getting too small at some browser widths, and too large at others.   Therefore,  we needed to come up with some formulas to compensate.

I didn't want the font-size to get any bigger than 14px because that is the font-size of the menu items of our browsers, which appear right below the tabs in a tabbed editor.  The max width of the TOC + the width  of the content (right side) comes to 1170px.   If the browser gets any bigger than this a margin is added around the guide content, but the content itself does not grow.  So, when the screen width is 1170px or greater the font will be held at 14px.  Under a width of 1170px we want the font to responsively grow/shrink between 10px and 14px to maximize the amount of the filename that appears in the tab.  That's where the viewport size comes into play.  The other "magic" number above is 768.   At 768px, bootstrap will go from our 2 column layout, where the tabbed editor was allotted 1/2 the width, to one column, where the width of the tabbed editor will get bigger and therefore the font in the tab should change to get bigger.

The two formulas used for font-size came from reading https://zellwk.com/blog/viewport-based-typography/. 
 
I wanted the font size to be between 10px and 14px.  10/14 = 0.714, or rounded to 70%.   Since our page sets 1em = 14px, I was able to also specify this as .70em.  In browsers such as IE, percentages in calc statements are not processed so for them I had to use .70em instead of 70%.  But I believe that for browsers like Safari the % is needed. This .70em indicates the font size at width 0.  To this we add the following.....

The second half of the formula is (the width of the viewport/the rate of growth).  To determine the width of the viewport I use 100vw, which is 100% of the browser width, and subtract the starting point width size for the CSS entry (320 and 768 in the formulas above).  

The rate of growth is the ratio:
  change in font size/ how many pixels the change should occur
So basically  I want the font size to change 4 px (which is the difference between the font-sizes I wanted to use: 14px - 10px = 4).  And the number of pixels the change should occur in is 402 for desktops (1170 - 768) and 447 for smaller screens (767-320).  In other words, for desktops, as the viewport width grows between 768px and 1170px I want the font size to grow 4 pixels.

Putting this all together, we get 
font-size: calc(.70em + 4 * (100vw - 320px) / 447)
and 
font-size: calc(.70em + 4 * (100vw - 768px) / 402)
