### PR TITLE
Updates to post warning messages in Editor

### DIFF
--- a/css/interactive-guides/editor.css
+++ b/css/interactive-guides/editor.css
@@ -89,3 +89,7 @@
   background-color: #f2dede;
   border: none;
 }
+
+.close_button_warning_editor {
+  background-color: #fcf8e3;
+}

--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -132,6 +132,9 @@ var editor = (function() {
         },
         createCustomErrorMessage: function(errorMsg){
             __createErrorAlertPane(this, 'alert-danger', false, true, errorMsg);
+        },
+        createCustomAlertMessage: function(alertMsg) {
+            __createErrorAlertPane(this, 'alert-warning', false, true, alertMsg);
         }
     };
 
@@ -339,7 +342,11 @@ var editor = (function() {
                 thisEditor.closeEditorErrorBox();
                 editorError.attr('tabindex', '-1');
             };
-            var closeButton = __createEditorErrorButton(idClose, "", "glyphicon glyphicon-remove-circle close_button_error_editor", handleOnClickClose, "Close error");
+            var bkgcolor = "";
+            if (alertClass === 'alert-warning') {
+                bkgcolor = "close_button_warning_editor";
+            } 
+            var closeButton = __createEditorErrorButton(idClose, "", "glyphicon glyphicon-remove-circle close_button_error_editor " + bkgcolor, handleOnClickClose, "Close error");
             editorError.append(closeButton);
         }
         editorError.append('</span>');

--- a/js/interactive-guides/utils.js
+++ b/js/interactive-guides/utils.js
@@ -51,7 +51,7 @@ var utils = (function() {
         quote = str.substring(0, 1);
         //console.log("quote ", quote);
         return quote;
-    }
+    };
 
     var __getAttributeAction = function(strAction, attr) {
         var str, resultStr;
@@ -83,7 +83,7 @@ var utils = (function() {
         resultStr = {attr: str, action: strAction}; 
         
         return resultStr;   
-    }
+    };
 
     var __getTitleAction = function(strAction) {
         var title = __getAttributeAction(strAction, "title=");
@@ -95,19 +95,19 @@ var utils = (function() {
         var str = __getAttributeAction(strAction, "onclick=");
         //console.log("onclick=", str.attr);
         return str; 
-    }
+    };
 
     var __getOnKeyPressAction = function(strAction) {
         var str = __getAttributeAction(strAction, "onkeypress=");
         //console.log("onkeypress=", str.attr);
         return str;
-    }
+    };
 
     var __getAriaLabelAction = function(strAction) {
         var str = __getAttributeAction(strAction, "aria-label=");
         //console.log("aria-label=", str.attr);
         return str;
-    }
+    };
     
     var __getButtonName = function(strName) {
         var buttonName;
@@ -177,14 +177,20 @@ var utils = (function() {
         } else {
             return false;
         }
-    }
+    };
+
+    var isInteger = function(value) {
+        var testRE = /^[0-9]+$/;
+        return (testRE.test(value));
+    };
 
     return {
         formatString: __formatString,
         parseString: __parseString,
         replaceString: __replaceString,
         parseActionTag: __parseActionTag,
-        isElementActivated: isElementActivated
+        isElementActivated: isElementActivated,
+        isInteger: isInteger
     };
 
 })();


### PR DESCRIPTION
Add the ability to post a warning message in the editor, besides the generic 'Read-only' message. The message should be accompanied by a close button (ie. the 'x') as is done with the error messages.