### PR TITLE
Even padding for playground instruction

### DIFF
--- a/css/interactive-guides/step-content.css
+++ b/css/interactive-guides/step-content.css
@@ -32,6 +32,7 @@
 
 .playgroundInstructionStyle {
   display: inline-block; 
-  padding-left: 41px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 


### PR DESCRIPTION
Set the padding for both sides of an instruction block that will never get a checkmark, for example, those on the playground step, to 20px padding both sides.