### PR TITLE
Correct parameters to enableRefreshButton on webBrowser

### DIFF
--- a/js/interactive-guides/modules/web-browser.js
+++ b/js/interactive-guides/modules/web-browser.js
@@ -187,7 +187,7 @@ var webBrowser = (function(){
           if (content.enableRefreshButton != undefined) {
             // The Refresh button is automatically enabled.  However at creation
             // you can select to disable the button for this web browser instance.
-            thisWebBrowser.enableRefreshButton(thisWebBrowser, content.enableRefreshButton);
+            thisWebBrowser.enableRefreshButton(content.enableRefreshButton);
           }
 
           if (content.enableStatusBar !== undefined) {


### PR DESCRIPTION
Fixing a defect.  enableRefreshButton() only takes one parameter, a boolean.  In the create() method for the WebBrowser we were passing two parameters to enableRefreshButton().  The first parameter was not needed.  

The problem was that if you wanted to enable the refreshButton for the browser it was not working.  Fortunately, we default to having the button enabled so no guides had yet invoked enableRefreshButton with true, only with false.