### PR TITLE
Add .sectlevel1 class to the TOC container for multipane TOC styling

### DIFF
--- a/js/interactive-guides/table-of-contents.js
+++ b/js/interactive-guides/table-of-contents.js
@@ -43,7 +43,7 @@ var tableofcontents = (function() {
     var __create = function(title, steps){
         __steps = steps;   // Save a local pointer to the steps array, managed by step-content.js
 
-        var container = $("#toc_container");
+        var container = $("#toc_container .sectlevel1");
         container.attr("role", "application");
         container.attr("aria-label", "Table of contents");
         $(ID.tableOfContentsTitle).after(container);


### PR DESCRIPTION
New multipane TOC styling relies on the .sectlevel1 class to be present.  Add to our interactive guides table-of-contents.js.