### PR TITLE
Put guide contents into one column (#guide_column).

### DIFF
--- a/css/interactive-guides/main.css
+++ b/css/interactive-guides/main.css
@@ -8,14 +8,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-#toc_guide_title {
-  padding-top: 30px;
-}
-
-#first_step_header:focus {
-  outline:none;
-}
-
 #guide_content pre.CodeMirror-line {
   border-radius: unset;
   border: unset;
@@ -70,69 +62,6 @@
   text-align: left;
   font-size: 16px;
   width: 100%;
-}
-
-.navButton {
-  width: 150px;
-  color: #8791AA;
-  background-color: transparent;
-  border: solid 2px #8791AA;
-  border-radius: 100px;
-  transition: all .2s;
-  visibility: hidden;
-}
-.navButton:hover,
-.navButton:focus {
-  color: white;
-  background-color: #8791AA;
-  border-color: #8791AA;
-}
-
-#prev_button {
-  text-align: right;
-  padding-right: 20px;
-  background-image: url(/guides/iguides-common/img/interactive-guides/guides_btnarrow_previous.svg);
-  background-repeat: no-repeat;
-  background-position: left 15px center;
-}
-#prev_button:hover,
-#prev_button:focus {
-  background-image: url(/guides/iguides-common/img/interactive-guides/guides_btnarrow_previous_hover.svg);
-  outline: none;
-}
-
-#next_button {
-  float: right;
-  text-align: left;
-  padding-left: 20px;
-  background-image: url(/guides/iguides-common/img/interactive-guides/guides_btnarrow_next.svg);
-  background-repeat: no-repeat;
-  background-position: right 15px center;
-}
-#next_button:hover,
-#next_button:focus {
-  background-image: url(/guides/iguides-common/img/interactive-guides/guides_btnarrow_next_hover.svg);  
-  outline: none; 
-}
-
-#next_button.green {
-  background-image: url(/guides/iguides-common/img/interactive-guides/guides_btnarrow_next_greenbtn.svg);
-  background-color: #ABD155;
-  border: 2px solid #A9D155;
-  color: #282A4A;
-}
-
-#next_button.green:hover, 
-#next_button.green:focus,
-#next_button.green:active {
-  background-color: #C7EE63;
-  border: 2px solid #C7EE63;
-}
-
-@media (max-width: 767px) {
-  .navButton {
-    width: 130px;
-  }
 }
 
 action.disabled {

--- a/html/interactive-guides/blueprint.html
+++ b/html/interactive-guides/blueprint.html
@@ -10,8 +10,6 @@
 -->
 <div id="blueprint">
   <div id="main">
-    <div id="blueprint_description"></div>
-    <div id="blueprint_instruction"></div>
     <div id="blueprint_step_content">
         <div id="contentContainer"></div>
     </div>

--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -11,86 +11,30 @@
 var blueprint = (function(){
   var create = function(blueprintName) {
     __load().done(function(){
-      __setupLocalSession();      
+          __setupLocalSession();
           var steps = jsonGuide.getSteps(blueprintName);
-      
-          //TODO: do some smart checking to make sure it's Github link, and append paths better
-          var repo = jsonGuide.getGithubRepo(blueprintName);
-          if (repo) {
-            var repoIssues = repo + "/issues";
-            var repoPR = repo + "/pulls";
-        
-            var contributeStep = {
-              "name": "Contribute",
-              "title": "Contribute to this guide",
-              "description": [ "Is something missing or broken? Raise an <a target='_blank' rel='noopener noreferrer' href='" + repoIssues + "'>issue</a>, or send us a <a target='_blank' rel='noopener noreferrer' href='" + repoPR + "'>pull request</a>.",
-                                "<br><a target='_blank' rel='noopener noreferrer' href='" + repo + "'>View this guide on github.</a>"]
-            };
-            steps.push(contributeStep);
-
-            var relateGuides = $("#related-guides");
-            if (relateGuides.length > 0) {
-              var relateGuidesStep = {
-                "name": "RelateGuides",
-                "title": "Related guides",
-                "description": ["<div id=\"relateGuidesContent\"/>"]
-              };
-              steps.push(relateGuidesStep);
-            }          
-          }
-     
-          // Hide the #blueprint_title as it is not used in the interactive guides
-          $(ID.blueprintTitle).hide();      
-          
           stepContent.setSteps(steps);
-          var toc_title = jsonGuide.getGuideDisplayTitle(blueprintName);
-          tableofcontents.create(toc_title, steps);        
+          tableofcontents.create(steps);
+          stepContent.createGuideContents();
       
-          if (window.location.hash === "") {
-            // No step specified in the URL, so display the first page.
-            stepContent.createContents(steps[0], false);
-          } else {    
-            // The URL fragment indentifier (first hash (#) after the URL) indicates
-            // the user requested a specific page within the guide.  Go to it.
-            var hashValue = window.location.hash.substring(1);  // get rid of '#'
-            stepContent.createContentsFromHash(hashValue);
-          }
-
-          //On click listener functions for Previous and Next buttons
-          $(ID.prevButton).on('click', function(){
-            var prevStepName = tableofcontents.prevStepFromName(stepContent.getCurrentStepName());
-            stepContent.updateURLfromStepName(prevStepName);
-            // Updating the hash in the URL will kick off the window.onhashchange
-            // event which will update the page contents.  See window.onhashchange below.
-          });
-      
-          $(ID.nextButton).on('click', function(){
-            var nextStepName = tableofcontents.nextStepFromName(stepContent.getCurrentStepName());
-            stepContent.updateURLfromStepName(nextStepName);
-            // Updating the hash in the URL will kick off the window.onhashchange
-            // event which will update the page contents.  See window.onhashchange below.
-          });
+          // if (window.location.hash === "") {
+          //   // No step specified in the URL, so display the first page.
+          //   stepContent.createContents(steps[0], false);
+          // } else {    
+          //   // The URL fragment indentifier (first hash (#) after the URL) indicates
+          //   // the user requested a specific page within the guide.  Go to it.
+          //   var hashValue = window.location.hash.substring(1);  // get rid of '#'
+          //   stepContent.createContentsFromHash(hashValue);
+          // }
 
           // Monitor for hash changes to show the requested page.
           // Hash changes occur when the URL is updated with a new hash
-          // value (as in someone bookmarked one of the pages), when a new
-          // page is selected from the table of contents, or when the next
-          // or previous buttons are selected.
+          // value (as in someone bookmarked one of the pages) or when a new
+          // page is selected from the table of contents
           window.onhashchange = function() {
             var hashValue = window.location.hash.substring(1);  // get rid of '#'
             stepContent.createContentsFromHash(hashValue);
           };
-      
-          //adding aria-labels to previous/next buttons and using messages file for button text
-          $(ID.navButtons).attr('aria-label', messages.navigationButtons);
-          $(ID.prevButton).attr('aria-label', messages.prevButton);
-          $(ID.prevButton).append(messages.prevButton);
-          $(ID.nextButton).attr('aria-label', messages.nextButton);
-          $(ID.nextButton).prepend(messages.nextButton);
-      
-          // Todo move these
-          var guideName = jsonGuide.getGuideDisplayTitle(blueprintName);
-          $(ID.tableOfContentsTitle).text(guideName);
       
           calculateBackgroundContainer();    
       
@@ -122,7 +66,7 @@ var blueprint = (function(){
         deferred.resolve();
       },
       error: function (result) {
-        console.error("Could not load the edittor.html");
+        console.error("Could not load blueprint.html");
         deferred.resolve();
       }
     });

--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -36,25 +36,25 @@ var blueprint = (function(){
             stepContent.createContentsFromHash(hashValue);
           };
       
-          calculateBackgroundContainer();    
+//          calculateBackgroundContainer();    
       
-          $(window).resize(function(){
-            calculateBackgroundContainer();
-          });
+          // $(window).resize(function(){
+          //   calculateBackgroundContainer();
+          // });
     });    
   };
 
-  calculateBackgroundContainer = function(){
-    // Calculate the bottom of the table of contents
-    var tocParent = $("#toc_container").parent();
-    var backgroundMargin = parseInt($("#background_container").css('margin-top')) + parseInt($("#background_container").css('margin-bottom'));
-    var backgroundPadding = parseInt($("#background_container").css('padding-top')) + parseInt($("#background_container").css('padding-bottom'));
-    var minHeight = tocParent.offset().top + tocParent.height() + backgroundMargin + backgroundPadding;
+  // calculateBackgroundContainer = function(){
+  //   // Calculate the bottom of the table of contents
+  //   var tocParent = $("#toc_container").parent();
+  //   var backgroundMargin = parseInt($("#background_container").css('margin-top')) + parseInt($("#background_container").css('margin-bottom'));
+  //   var backgroundPadding = parseInt($("#background_container").css('padding-top')) + parseInt($("#background_container").css('padding-bottom'));
+  //   var minHeight = tocParent.offset().top + tocParent.height() + backgroundMargin + backgroundPadding;
 
-    // Extend the background container's min-height to cover the table of contents
-    $("#background_container").css('min-height', minHeight);
-    $("#background_container").css('background-size', "100% calc(100% - 50px)");
-  };
+  //   // Extend the background container's min-height to cover the table of contents
+  //   $("#background_container").css('min-height', minHeight);
+  //   $("#background_container").css('background-size', "100% calc(100% - 50px)");
+  // };
  
   var __load = function() {
     var deferred = new $.Deferred();

--- a/js/interactive-guides/id.js
+++ b/js/interactive-guides/id.js
@@ -9,13 +9,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 var ID = {
-    "tableOfContentsTitle": "#table_of_contents_title",
-    "blueprintTitle":       "#blueprint_title",
-    "blueprintDescription": "#blueprint_description",
-    "blueprintInstruction": "#blueprint_instruction",
-    "navButtons": "#page_nav_buttons",
-    "nextButton": "#next_button",
-    "prevButton": "#prev_button",
-    "first_step_header": "#first_step_header",
-    "toc_guide_title": "#toc_guide_title"
 };

--- a/js/interactive-guides/messages.js
+++ b/js/interactive-guides/messages.js
@@ -9,8 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 var messages = {
-  // Left pane
-  "tableOfContentsTitle":"BluePrint Overview",
   // Web Browser
   "browserSample": "Sample browser window",
   "browserAddressBar": "Sample browser address bar",
@@ -18,8 +16,6 @@ var messages = {
   "browserRefreshButton": "Refresh sample browser page",
   "navigationButtons": "Guide navigation buttons",
   "browserStatusBar": "Sample browser status bar",
-  "prevButton": "Previous",
-  "nextButton": "Next",
   "cmdPromptSample": "Terminal window",
   "cmdPromptHelpMessage": "Type \'help\' to get started.",
   "cmdPromptInput": "Enter a command",

--- a/js/interactive-guides/modules/content-manager.js
+++ b/js/interactive-guides/modules/content-manager.js
@@ -750,7 +750,6 @@ var contentManager = (function() {
                 }
                 else{
                     stepInstruction.currentInstructionIndex = -1;
-                    colorNextButton(true);
                 }
             }
         }
@@ -838,24 +837,11 @@ var contentManager = (function() {
       return stepInstruction ? stepInstruction.instructions.length-1 : -1;
     };
 
-    var colorNextButton = function(isComplete){
-        // Mark next button green if all instructions are complete
-        var nextButton = $('#next_button');
-        if(nextButton && nextButton.length > 0){
-            if(isComplete){
-                nextButton.addClass('green');
-            }     
-            else{
-                nextButton.removeClass('green');
-            }
-        }
-    };
-
     /*
         Check if all of the instructions for a given step are complete.
         Input: {stepName} Step name
     */
-    var enableNextWhenAllInstructionsComplete = function(step) {
+    var determineIfAllInstructionsComplete = function(step) {
         var stepName = step.name;
         var isComplete = true;
         var stepInstruction = __getStepInstruction(stepName);
@@ -876,8 +862,7 @@ var contentManager = (function() {
                     }
                 }                
             }
-        }        
-        colorNextButton(isComplete);        
+        }               
         return isComplete;        
     };
 
@@ -947,7 +932,7 @@ var contentManager = (function() {
         getCurrentInstructionIndex: getCurrentInstructionIndex,
         getInstructionAtIndex: getInstructionAtIndex,
         getInstructionsLastIndex: getInstructionsLastIndex,
-        enableNextWhenAllInstructionsComplete: enableNextWhenAllInstructionsComplete,
+        determineIfAllInstructionsComplete: determineIfAllInstructionsComplete,
         updateWithNewInstructionNoMarkComplete: updateWithNewInstructionNoMarkComplete
     };
 })();

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -92,7 +92,7 @@ var stepContent = (function() {
   }
 
   // Append the element's title to the content
-  var __addTitle = function(element) {
+  var __addTitleOLD = function(element) {
     if(!element.title){
       return;
     }
@@ -112,7 +112,7 @@ var stepContent = (function() {
   };
 
   // Append the element's title to the content
-  var __addTitle2 = function(element, $stepContent) {
+  var __addTitle = function(element, $stepContent) {
       if(!element.title){
         return;
       }
@@ -132,7 +132,7 @@ var stepContent = (function() {
   };
 
   // Append the step description text
-  var __addDescription = function(step) {
+  var __addDescriptionOLD = function(step) {
     if(!step.description){
       return;
     }
@@ -154,7 +154,7 @@ var stepContent = (function() {
   };
 
   // Append the step description text
-  var __addDescription2 = function(step, $stepContent) {
+  var __addDescription = function(step, $stepContent) {
     if(!step.description){
       return;
     }
@@ -188,7 +188,7 @@ var stepContent = (function() {
   };
 
   // Update the step instruction text
-  var __updateInstructions = function(step) {
+  var __updateInstructionsOLD = function(step) {
     var stepName = step.name;
 
     var index = 0;
@@ -233,13 +233,13 @@ var stepContent = (function() {
     if(step.sections){
       for(var i = 0; i < step.sections.length; i++){
         var section = step.sections[i];
-        __updateInstructions(section);
+        __updateInstructionsOLD(section);
       }
     }        
   };
 
     // Update the step instruction text
-    var __updateInstructions2 = function(step, $stepContent) {
+    var __updateInstructions = function(step, $stepContent) {
       var stepName = step.name;
   
       var index = 0;
@@ -284,7 +284,7 @@ var stepContent = (function() {
       if(step.sections){
         for(var i = 0; i < step.sections.length; i++){
           var section = step.sections[i];
-          __updateInstructions2(section, $stepContent);
+          __updateInstructions(section, $stepContent);
         }
       }        
     };  
@@ -440,10 +440,10 @@ var stepContent = (function() {
       $stepContent = $("<div class='sect1'></div>");
       $("#contentContainer").append($stepContent);
 
-      __buildContent2(step, $stepContent);
+      __buildContent(step, $stepContent);
       if(step.sections){
         for(var j = 0; j < step.sections.length; j++){
-          __buildContent2(step.sections[j], $stepContent);
+          __buildContent(step.sections[j], $stepContent);
         }
       }
     }
@@ -451,12 +451,12 @@ var stepContent = (function() {
     createEndOfGuideContent();
   };
 
-  var __buildContent2 = function(step, $stepContent) {
+  var __buildContent = function(step, $stepContent) {
     contentManager.setInstructions(step.name, step.instruction);
 
-    __addTitle2(step, $stepContent);
-    __addDescription2(step, $stepContent);
-    __updateInstructions2(step, $stepContent);    
+    __addTitle(step, $stepContent);
+    __addDescription(step, $stepContent);
+    __updateInstructions(step, $stepContent);    
 
 //     if (step.content) {
 //       var content = step.content;        
@@ -566,10 +566,10 @@ var stepContent = (function() {
       currentStepName = step.name;
             
       if (!__lookForExistingContents(step)) {
-        __buildContent(step);
+        __buildContentOLD(step);
         if(step.sections){
           for(var i = 0; i < step.sections.length; i++){
-            __buildContent(step.sections[i]);
+            __buildContentOLD(step.sections[i]);
           }
         }
       }
@@ -587,12 +587,12 @@ var stepContent = (function() {
     __addMarginToLastInstruction();
   };
 
-  var __buildContent = function(step) {
+  var __buildContentOLD = function(step) {
     contentManager.setInstructions(step.name, step.instruction);
 
-    __addTitle(step);
-    __addDescription(step);
-    __updateInstructions(step);    
+    __addTitleOLD(step);
+    __addDescriptionOLD(step);
+    __updateInstructionsOLD(step);    
 
     if (step.content) {
       var content = step.content;        

--- a/js/interactive-guides/table-of-contents.js
+++ b/js/interactive-guides/table-of-contents.js
@@ -36,17 +36,15 @@ var tableofcontents = (function() {
 
     /*
         Creates the table of contents for the BluePrint based on the JSON representation.
-        Input: 
-          title - string - guide display title
+        Input:
           steps - array - the steps of the BluePrint represented as JSON
     */
-    var __create = function(title, steps){
+    var __create = function(steps){
         __steps = steps;   // Save a local pointer to the steps array, managed by step-content.js
 
         var container = $("#toc_container .sectlevel1");
         container.attr("role", "application");
         container.attr("aria-label", "Table of contents");
-        $(ID.tableOfContentsTitle).after(container);
 
         // Loop through the steps and append each one to the table of contents.
         for(var i = 0; i < steps.length; i++){
@@ -158,10 +156,6 @@ var tableofcontents = (function() {
           // Enter key or space key
           if(event.which === 13 || event.which === 32){
             span.click();
-
-            if(__getStepIndex(element.name) === 0){
-              $(ID.first_step_header).attr("tabindex","0");
-            }
           }
         });
 
@@ -187,7 +181,6 @@ var tableofcontents = (function() {
         Select the step in the table of contents and scroll to its contents.  
     */
     var __selectStep = function(stepObj){  
-      stepContent.handleFirstStepContent(stepObj.parent ? stepObj.parent.name : stepObj.name); // Handle hiding/showing the first step's title   
       __highlightTableOfContents(stepObj.name);
       __scrollToContent(stepObj.name);
     
@@ -217,16 +210,6 @@ var tableofcontents = (function() {
           return this.css('visibility', 'hidden');
       };
 
-      if (stepIndex == 0) {
-        $(ID.prevButton).invisible();
-      } else {
-        $(ID.prevButton).visible();
-      }
-      if (stepIndex == last) {
-        $(ID.nextButton).invisible();
-      } else {
-        $(ID.nextButton).visible();
-      }
     };
 
     return {


### PR DESCRIPTION
Begin conversion to the multi-pane layout be loading the guide contents (text only) into the single column as defined by the multipane layout design.  

**NOTE:** This PR is not complete and I will continue to make enhancements to it.

This PR does the following:
- Loads all the steps at one time
- Loads the text of the steps.  All widgets, which will be moved to the third column, are no longer displayed in the #guide_column container.
- Removed the navigation buttons ('Previous' and 'Next')
- Removed '#blueprint_description' and '#blueprint_instruction' from blueprint.html.   This information is contained within the header design of the multipane layout.
- Removed 'Related guides' section as this now appears in the multipane layout footer(?) section.
- No longer compute the background container as this is now handled by the multipane layout in openliberty.io
- Update id.js so that the strings defined in the multipane layout in openliberty.io are not duplicated.  This leaves this file empty, but didn't delete the file in case we need to use it for special strings common to all interactive guides.

Updates made to js/interactive-guides/step-content.js include renaming many of the existing methods to ***OLD( ) and then creating a new method with the same name that will work with the same layout.  For example, the file now contains addDescription( ) and addDescriptionOLD( ).  The reason I did this is to have the old code readily available as I work through the flow of laying out an interactive guide to easily see where the differences between the interactive and static guides exist.  I am working on cleaning this up and will get rid of all the ***OLD( ) methods in a future PR.  
