### PR TITLE
Iguide TOC

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -26,7 +26,7 @@ var blueprint = (function(){
             event.preventDefault();
 
             var hash = location.hash.substring(1);
-            stepContent.setCurrentStepName(hash);
+            stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash));
           });
 
           if (window.location.hash !== "") {   
@@ -36,6 +36,7 @@ var blueprint = (function(){
             // the user requested a specific page within the guide.  Go to it.
             var hash = location.hash;
             accessContentsFromHash(hash);
+            stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash.substring(1)));
           }
     });    
   };

--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -23,14 +23,19 @@ var blueprint = (function(){
           // page is selected from the table of contents.
           // HashChange event processing also occurs in content\common-multipane.js.
           window.addEventListener("hashchange", function(){
-            var id = location.hash.substring(1);
-            stepContent.setCurrentStepName(id);
+            event.preventDefault();
+
+            var hash = location.hash.substring(1);
+            stepContent.setCurrentStepName(hash);
           });
 
           if (window.location.hash !== "") {   
+            handleFloatingTableOfContent();
+            
             // The URL fragment indentifier (first hash (#) after the URL) indicates
             // the user requested a specific page within the guide.  Go to it.
-            stepContent.accessContentsFromHash();
+            var hash = location.hash;
+            accessContentsFromHash(hash);
           }
     });    
   };

--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -17,41 +17,23 @@ var blueprint = (function(){
           tableofcontents.create(steps);
           stepContent.createGuideContents();
       
-          if (window.location.hash !== "") {   
-            // The URL fragment indentifier (first hash (#) after the URL) indicates
-            // the user requested a specific page within the guide.  Go to it.
-            var hashValue = window.location.hash.substring(1);  // get rid of '#'
-            stepContent.accessContentsFromHash(hashValue);
-          }
-
           // Monitor for hash changes to show the requested page.
           // Hash changes occur when the URL is updated with a new hash
           // value (as in someone bookmarked one of the pages) or when a new
-          // page is selected from the table of contents
-          window.onhashchange = function() {
-            var hashValue = window.location.hash.substring(1);  // get rid of '#'
-            stepContent.accessContentsFromHash(hashValue);
-          };
-      
-//          calculateBackgroundContainer();    
-      
-          // $(window).resize(function(){
-          //   calculateBackgroundContainer();
-          // });
+          // page is selected from the table of contents.
+          // HashChange event processing also occurs in content\common-multipane.js.
+          window.addEventListener("hashchange", function(){
+            var id = location.hash.substring(1);
+            stepContent.setCurrentStepName(id);
+          });
+
+          if (window.location.hash !== "") {   
+            // The URL fragment indentifier (first hash (#) after the URL) indicates
+            // the user requested a specific page within the guide.  Go to it.
+            stepContent.accessContentsFromHash();
+          }
     });    
   };
-
-  // calculateBackgroundContainer = function(){
-  //   // Calculate the bottom of the table of contents
-  //   var tocParent = $("#toc_container").parent();
-  //   var backgroundMargin = parseInt($("#background_container").css('margin-top')) + parseInt($("#background_container").css('margin-bottom'));
-  //   var backgroundPadding = parseInt($("#background_container").css('padding-top')) + parseInt($("#background_container").css('padding-bottom'));
-  //   var minHeight = tocParent.offset().top + tocParent.height() + backgroundMargin + backgroundPadding;
-
-  //   // Extend the background container's min-height to cover the table of contents
-  //   $("#background_container").css('min-height', minHeight);
-  //   $("#background_container").css('background-size', "100% calc(100% - 50px)");
-  // };
  
   var __load = function() {
     var deferred = new $.Deferred();

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -89,7 +89,8 @@ var stepContent = (function() {
     Return the step or section name value associated with the hash value.  
     If the hash is not recognized, return an empty string.
 
-    hash - string - hash value for a step.  Created in __createStepHashIdentifier().
+    hash - string - hash value for a step.  Created in __createStepHashIdentifier(),
+                    so it should NOT be preceeded with '#'.
   */
   var getStepNameFromHash = function(hash) {
     return hashStepNames[hash] ? hashStepNames[hash] : "";

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -82,7 +82,7 @@ var stepContent = (function() {
   };
 
   var setCurrentStepName = function(stepName) {
-    currentStepName = stepName;
+    currentStepName = stepName;   
   }
 
   /* 
@@ -91,7 +91,7 @@ var stepContent = (function() {
 
     hash - string - hash value for a step.  Created in __createStepHashIdentifier().
   */
-  var __getStepNameFromHash = function(hash) {
+  var getStepNameFromHash = function(hash) {
     return hashStepNames[hash] ? hashStepNames[hash] : "";
   };
 
@@ -148,6 +148,7 @@ var stepContent = (function() {
         }
     return false;
   };
+
   // Update the step instruction text
   var __updateInstructions = function(step, $stepContent) {
     var stepName = step.name;
@@ -161,16 +162,13 @@ var stepContent = (function() {
       var instruction = contentManager.getInstructionAtIndex(index, stepName);
       instruction = __parseInstructionForActionTag(instruction);
       //console.log("new instruction ", instruction);
-      // Special instruction to track whether the user has completed something but the instruction should not be shown in the DOM.
       if(instruction){
         // Append the instruction to the bottom of the current content.
         var instr = $(".instructionContent[data-step='" + stepName + "'][data-instruction='" + index + "']");
-          instr = __addInstructionTag(stepName, instruction, index);
-          $stepContent.append(instr);
-
+        instr = __addInstructionTag(stepName, instruction, index);
+        $stepContent.append(instr);
       }
     }
-
   };
 
   var __addInstructionTag = function (stepName, instruction, index) {
@@ -348,132 +346,12 @@ var stepContent = (function() {
 //     }
   };
 
-  /*
-    Shows the first page of the guide, but not selected.  Therefore, the
-    Guide Header is seen.
-
-    This situation occurs when we first enter the guide or when a unknown
-    hash is provided in the URL.
-  */
-  var __defaultToFirstPage = function() {
-    window.location.hash = "";
-    currentStepName = "";
-    $('.selectedStep').removeClass('selectedStep');
-  };
-
-  /*
-    Displays the step associated with a given step name.  If no step is 
-    associated with the stepName, the first page is shown.  
-  */
-  var accessContentsFromName = function(stepName){
-    if (stepName) {
-      var hashValue = __createStepHashIdentifier(stepName);
-      var requestedStepName = __getStepNameFromHash(hashValue);
-      if (requestedStepName) {
-        __accessContents(hashValue, requestedStepName);
-      } else {
-        __defaultToFirstPage();
-      }
-    } else {
-      // Default to the first page of the guide.  Set the URL appropriately.
-      __defaultToFirstPage();
-    }
-  };
-
-  /*
-    Displays the step associated with the inputted hash value.
-    If no step is associated with the hashValue, the first page is shown.
-  */
-  var accessContentsFromHash = function() {
-    var hashValue = window.location.hash.substring(1);  // get rid of '#'
-    // Validate the hash value
-    var requestedStepName = __getStepNameFromHash(hashValue);
-    if (requestedStepName) {
-      __accessContents(hashValue, requestedStepName);
-    } else {
-      // If the hash did not point to an existing step, default
-      // to show the first step of the guide but don't have it selected
-      // since it was not specified.
-      __defaultToFirstPage();
-    }
-  };
-
-  var __accessContents = function(hashValue, stepName) {
-    handleFloatingTableOfContent();    // Common method with static guides
-    updateTOCHighlighting(hashValue);  // Common method with static guides
-
-//    __scrollToContent(hashValue, requestedStepName);
-    __updateURLwithStepHash(hashValue);
-    shiftWindow();
-    
-    currentStepName = stepName;
-  };
-
-  /* 
-    Given a step's hash value, scroll to its contents, and put the focus on
-    the first part of its description.
-    Input: stepHash: String - hash value for the step (ID not name)
-  */
-   var __scrollToContent = function(stepHash, stepName){    
-    var focusSection = $(".title[id='" + stepHash +"']");
-    var headerAdjust = $('.container-fluid').height() | 0;
-  
-    // If the section is found scroll to it
-    if(focusSection.length > 0){
-      $("html, body").animate({ scrollTop: focusSection.offset().top - headerAdjust}, 400);
-      focusSection.siblings('.description[data-step="' + stepName + '"]').focus();
-    }
-    // Otherwise, scroll to the top of the guide
-    else {
-      __defaultToFirstPage();
-    }   
-  };
-
-  var updateURLfromStepName = function(stepName) {
-    var hashName = "";
-    $.each(hashStepNames, function(key, value){
-      if (value === stepName) {
-        hashName = key;
-        return false;
-      }
-    });
-
-    __updateURLwithStepHash(hashName);
-  };
-
-  var updateURLfromStepTitle = function(stepTitle) {
-    var hashName = __createStepHashIdentifier(stepTitle);
-
-    if (!hashStepNames[hashName]) {
-      hashName = "";
-    }
-
-    __updateURLwithStepHash(hashName);
-  };
-
-  var __updateURLwithStepHash = function(hashName) {
-    var URL = location.href;
-    if (URL.indexOf('#') != -1) {
-      URL = URL.substring(0, URL.indexOf('#'));
-    }
-
-    if (hashName) {
-      URL += '#' + hashName;
-    }
-
-    location.href = URL;
-  };
-
   return {
     setSteps: setSteps,
-    createGuideContents: createGuideContents,
-    createStepHashIdentifier: __createStepHashIdentifier,    
-    accessContentsFromHash: accessContentsFromHash,
-    accessContentsFromName: accessContentsFromName,
+    createStepHashIdentifier: __createStepHashIdentifier,
     getCurrentStepName: getCurrentStepName,
     setCurrentStepName: setCurrentStepName,
-    getStepNameFromHash: __getStepNameFromHash,
-    updateURLfromStepName: updateURLfromStepName,
-    updateURLfromStepTitle: updateURLfromStepTitle
+    getStepNameFromHash: getStepNameFromHash,
+    createGuideContents: createGuideContents
   };
 })();

--- a/js/interactive-guides/table-of-contents.js
+++ b/js/interactive-guides/table-of-contents.js
@@ -52,23 +52,17 @@ var tableofcontents = (function() {
           __buildStep(container, step);
         }
 
-        // Set click processing for TOC.   These onclick handlers should match the
-        // actions in ...content\assests\js\toc-multipane.js.  It is duplicated 
+        // Set click processing for TOC entries. This onclick handler should match
+        // the actions in ...content\assests\js\toc-multipane.js.  It is duplicated
         // here because the interactive guide TOC list items are created AFTER
         // the main document loads.
         $("#toc_container li").on('click', function(event) {
-          // 'this' is the li element.  Its first child is the anchor tag.
-          var hash = $(this).find('a').prop('hash').substring(1);  // Get rid of the '#' of the hash
+          // 'this' is the li element in the #toc_container.
+          TOCentryClick(this, event);
 
-          // Update the URL hash with where we wish to go....
-          window.location.hash = hash; // NOTE: hashchange handling invokes 
-                                       //       updateTOCHighlighting(id) and
-                                       //       handleFloatingTableOfContent();
-          if(inSingleColumnView()){
-              $("#mobile_close_container").trigger('click');
-          }
-        });
-  
+          var hash = window.location.hash.substring(1);  // Remove the '#'
+          stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash));
+        }); 
     };
 
     /*
@@ -128,11 +122,9 @@ var tableofcontents = (function() {
         }
       }
 
-      // Used for previous/next button functionality.
-      // NOTE: sections aren't added to this array since they don't have their own
-      //       previous and next buttons.
+      // NOTE: Sections aren't added to this array since they are part of 
+      //       a parent page.
       orderedStepNamesArray.push(step.name);
-
     };
 
     /*

--- a/js/interactive-guides/table-of-contents.js
+++ b/js/interactive-guides/table-of-contents.js
@@ -52,6 +52,23 @@ var tableofcontents = (function() {
           __buildStep(container, step);
         }
 
+        // Set click processing for TOC.   These onclick handlers should match the
+        // actions in ...content\assests\js\toc-multipane.js.  It is duplicated 
+        // here because the interactive guide TOC list items are created AFTER
+        // the main document loads.
+        $("#toc_container li").on('click', function(event) {
+          // 'this' is the li element.  Its first child is the anchor tag.
+          var hash = $(this).find('a').prop('hash').substring(1);  // Get rid of the '#' of the hash
+
+          // Update the URL hash with where we wish to go....
+          window.location.hash = hash; // NOTE: hashchange handling invokes 
+                                       //       updateTOCHighlighting(id) and
+                                       //       handleFloatingTableOfContent();
+          if(inSingleColumnView()){
+              $("#mobile_close_container").trigger('click');
+          }
+        });
+  
     };
 
     /*
@@ -60,8 +77,8 @@ var tableofcontents = (function() {
        The value is set as the 'TOCIndent' property of the guide's JSON file describing the steps.
        If 'TOCIndent' is not specified in the JSON for the step, a value of '0' is assumed and 
        the step's title appears at the leftmost edge of the TOC.
-       Input: container: div - table of contents container for where the list item should be added
-              dataTOC: string - data attribute to identify the list item
+       Input: container: div - table of contents container
+              dataTOC: string - step NAME, not it's Title, associated with this TOC entry
               title: title to display in the table of contents list item
               depth: how many levels the entry is indented.  '0' is no indent or leftmost edge. 
     */
@@ -73,14 +90,13 @@ var tableofcontents = (function() {
         // Indent based on depth
         listItem.css('margin-left', depth * 30 + 'px');
       
-        // Create a span and set the text and attributes
-        var span = $("<span class='tableOfContentsSpan'>");
-        span.attr('tabindex', '0');
-        span.attr('aria-label', title);
-        span.text(title);
+        // Create an anchor <a> tag for the TOC entry.
+        var stepHash = stepContent.createStepHashIdentifier(title);
+        var anchor = $("<a href='#" + stepHash + "'>");
+        anchor.text(title);
 
-        // Append the span to the list item and then add it to the container
-        listItem.append(span);
+        // Append the anchor to the list item and then add it to the container
+        listItem.append(anchor);
         container.append(listItem);
         return listItem;
     };
@@ -91,7 +107,7 @@ var tableofcontents = (function() {
     */
     var __buildStep = function(container, step){
       var listItem = __createListItem(container, step.name, step.title, step.TOCIndent || 0);
-       __addOnClickListener(listItem, step);
+      __addOnClickListener(listItem);
 
       // A section is a portion of a step that appears in the TOC as a separate, indented entry
       // following the step's entry.  It appears on the same PAGE as the step, but has its
@@ -108,7 +124,7 @@ var tableofcontents = (function() {
           // Sections, in the TOC, are indented one from their parent.
           var depth = step.TOCIndent ? step.TOCIndent + 1: 1;
           var subStepLink = __createListItem(container, section.name, section.title, depth);
-          __addOnClickListener(subStepLink, section);
+          __addOnClickListener(subStepLink);
         }
       }
 
@@ -119,104 +135,22 @@ var tableofcontents = (function() {
 
     };
 
-    var __scrollToContent = function(stepName){    
-      var focusSection = $(".title[data-step='" + stepName + "']");
-      
-      // If the section is found scroll to it
-      if(focusSection.length > 0){
-        $("html, body").animate({ scrollTop: focusSection.offset().top }, 400);
-        focusSection.siblings('.description[data-step="' + stepName + '"]').focus();
-      }
-      // Otherwise, scroll to the top of the step
-      else{
-        $("html, body").animate({ scrollTop: $("#guide_column").offset().top }, 400);
-        focusSection.siblings('.description[data-step="' + stepName + '"]').focus();
-      }   
-    };
-    
     /*
-        Handler for clicking on a step or section in the table of contents.
+        Add handler to <li>s in the TOC
         Input: 
           listItem - html <li> item in TOC representing the step or section
-          element - JSON containing information for the step or section.
-                    element.name is the identity of the element within the DOM.
     */
-    var __addOnClickListener = function(listItem, element) {
-        var span = listItem.find('.tableOfContentsSpan');
-        span.on("click", function(event){
-            event.preventDefault();
-            event.stopPropagation();
-
-            stepContent.updateURLfromStepTitle(element.title);
-            // Updating the hash in the URL will kick off the window.onhashchange
-            // event which will update the page contents.  See blueprint.js.
-        });
-
-        span.on("keydown", function(event){
-          // Enter key or space key
-          if(event.which === 13 || event.which === 32){
-            span.click();
-          }
-        });
-
-        // Prevent the focus state when clicking
-        listItem.on("mousedown", function(event){
-          event.preventDefault();
-          event.stopPropagation();
-        });
-    };
-
-    var __getStepElement = function(name){
-      return $("[data-toc='" + name + "']");
-    };
-
-    var __highlightTableOfContents = function(name){
-      // Clear previously selected step and highlight step
-      $('.selectedStep').removeClass('selectedStep');
-      var $step = __getStepElement(name);
-      $step.addClass('selectedStep');
-    };
-
-    /*
-        Select the step in the table of contents and scroll to its contents.  
-    */
-    var __selectStep = function(stepObj){  
-      __highlightTableOfContents(stepObj.name);
-      __scrollToContent(stepObj.name);
-    
-    };
-    
-    /*
-      Determine if the previous/next buttons should be visible on the page.
-    */
-    var __addPreviousNext = function(stepObj) {
-
-      // Don't show/hide the previous/next buttons based on this section if this is a
-      // section of a parent's step.  Sections appear on the same page as its parent step,
-      // so they don't have their own previous/next buttons.
-      if(stepObj.parent){
-        return;
-      }
-
-      //Hide the previous and next buttons when not needed
-      var stepIndex = orderedStepNamesArray.indexOf(stepObj.name);
-      var last = orderedStepNamesArray.length - 1;
-
-      jQuery.fn.visible = function() {
-        return this.css('visibility', 'visible');
-      };
-
-      jQuery.fn.invisible = function() {
-          return this.css('visibility', 'hidden');
-      };
-
+    var __addOnClickListener = function(listItem) {
+          listItem.on("keydown", function(event) {
+            if (event.which === 13 || event.which === 32) {   // Spacebar or Enter
+              listItem.click();
+            }
+          });
     };
 
     return {
       create: __create,
-      selectStep: __selectStep,
       getStepIndex: __getStepIndex,
-      addPreviousNext: __addPreviousNext,
       nextStepFromName: __getNextStepFromName,
       prevStepFromName: __getPrevStepFromName
     };


### PR DESCRIPTION
Enable the new TOC processing in the interactive guides. Code should be rearranged to work with the static guides.

Changes include:

**blueprint.js**: Setting up a separate hashChange handler for the interactive guides to keep the currentStepName in stepContent.js correct.   Also, invoke the common accessContentsFromHash() in common-multipane.js for processing a hash that may be present when you initially invoke the guide.  Remove backgroundContainer stuff since it is no longer needed now that the interactive guide is hooked up with the static guide.

**step-content.js**: Add setCurrentStepName().  Removed many unneeded methods.

**table-of-contents.js**: Set the \<li> onClick handler for each entry in the TOC.  It will invoke the common TOCentryClick() method in TOC-multipane.js for smooth scrolling to the requested section.  Change the contents of the \<li> entries representing each TOC element to be an \<a> anchor to match the layout of the static guides.  Previously it was a \<span>.  Removed scrollToContent() since smooth scrolling is now being handled in  the common accessContentsFromHash() in common-multipane.js.  Removed a bunch of methods that are now being handled by the common TOC-multipane.js so that the interactive guides look and act as the static guides.