### PR TITLE
Add onScroll handler to monitor scrolling through pages

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -38,6 +38,17 @@ var blueprint = (function(){
             accessContentsFromHash(hash);
             stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash.substring(1)));
           }
+
+          $(window).on('scroll', function(event) {
+            // Check if a scroll animation from another piece of code is taking
+            // place and prevent normal behavior.
+            // NOTE: 'scrolling' flag is set in common-multipane.js accessContentsFromHash()
+            //       to indicate when scrolling to a selected section is in progress.
+            if($("body").data('scrolling') === true) {
+                return;
+            }
+            handleSectionSnapping(event);
+          });
     });    
   };
  
@@ -82,7 +93,34 @@ var blueprint = (function(){
         }
       });
     }
-  }
+  };
+
+  var handleSectionSnapping = function(event) {
+    // Multipane view
+    if(window.innerWidth > twoColumnBreakpoint) {
+      var id = getScrolledVisibleSectionID();
+      if (id !== null) {
+        var windowHash = window.location.hash;
+        var scrolledToHash = id === "" ? id : '#' + id;
+        if (windowHash !== scrolledToHash) {
+          // Update the URL hash with new section we scrolled into....
+          var currentPath = window.location.pathname;
+          var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
+          // Not setting window.location.hash here because that causes an
+          // onHashChange event to fire which will scroll to the top of the
+          // section.  pushState updates the URL without causing an
+          // onHashChange event.
+          history.pushState(null, null, newPath);
+
+          // Update the selected TOC entry
+          updateTOCHighlighting(id);
+
+          // Match the code block on the right to the new id
+          stepContent.showStepWidgets(id);
+        }
+      }
+    }
+  };
 
   return {
     create: create

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -247,8 +247,11 @@ var stepContent = (function() {
 
       __buildContent(step, $stepContent);
       if(step.sections){
+        var $sectionContent;
         for(var j = 0; j < step.sections.length; j++){
-          __buildContent(step.sections[j], $stepContent);
+          $sectionContent = $("<div class='sect2' id'" + step.name + "_content'></div>");
+          $stepContent.append($sectionContent);
+          __buildContent(step.sections[j], $sectionContent);
         }
       }
     }
@@ -340,12 +343,18 @@ var stepContent = (function() {
     }
   };
 
+  // Update widgets displayed on right-hand side of multipane layout for the specified id.
+  var showStepWidgets = function(id) {
+    console.log("show widgets for step " + id);
+  };
+
   return {
     setSteps: setSteps,
     createStepHashIdentifier: __createStepHashIdentifier,
     getCurrentStepName: getCurrentStepName,
     setCurrentStepName: setCurrentStepName,
     getStepNameFromHash: getStepNameFromHash,
-    createGuideContents: createGuideContents
+    createGuideContents: createGuideContents,
+    showStepWidgets: showStepWidgets
   };
 })();


### PR DESCRIPTION
Add the onScroll handler to monitor scrolling through the pages when in multi-column format.   It will invoke  getScrolledVisibleSectionID() in common-multipane.js to get the ID of the guide section or page that is taking the majority of the vertical space on the page.  After returning the ID it sets the hash in the URL to match the id and updates the TOC.  Then it invokes a dummy method, stepContent.showWidgets(id) that can be used to update the right-hand column when needed.

Updated the **sections** in the interactive guides to be contained within a div with class .sect2 to mimic what is done in the static guides.