### PR TITLE
Switch to correct widgets when selected step changes in multipane mode.

### DIFF
--- a/css/interactive-guides/step-content.scss
+++ b/css/interactive-guides/step-content.scss
@@ -18,6 +18,18 @@
   opacity: 0.5;
 }
 
+.multicolStepShown {
+  display: block;
+}
+
+.multicolStepHidden {
+  display: none;
+
+  @media (max-width: 1170px) {
+    display: block;
+  }
+}
+
 @media (max-width: 450px) {
   .subContainerDiv {
     margin-bottom: 60px;

--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -37,6 +37,8 @@ var blueprint = (function(){
             // the user requested a specific page within the guide.  Go to it.
             var hash = location.hash;
             accessContentsFromHash(hash);
+            // Match the widgets on the right to id
+            stepContent.showStepWidgets(hash.substring(1));
             stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash.substring(1)));
           }
 
@@ -116,7 +118,7 @@ var blueprint = (function(){
           // Update the selected TOC entry
           updateTOCHighlighting(id);
 
-          // Match the code block on the right to the new id
+          // Match the widgets on the right to the new id
           stepContent.showStepWidgets(id);
         }
       }

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -252,7 +252,7 @@ var stepContent = (function() {
       if(step.sections){
         var $sectionContent;
         for(var j = 0; j < step.sections.length; j++){
-          $sectionContent = $("<div class='sect2' id'" + step.name + "_content'></div>");
+          $sectionContent = $("<div class='sect2' id='" + step.sections[j].name + "_content'></div>");
           $stepContent.append($sectionContent);
           __buildContent(step.sections[j], $sectionContent);
         }
@@ -323,7 +323,7 @@ var stepContent = (function() {
     if ($(".stepWidgetContainer[data-step='" + step.name + "']").length > 0) {
         stepWidgets = $(".stepWidgetContainer[data-step='" + step.name + "']");
     } else { // create div
-        stepWidgets = $("<div class='stepWidgetContainer' data-step='" + step.name + "'></div>");
+        stepWidgets = $("<div class='stepWidgetContainer multicolStepHidden' data-step='" + step.name + "'></div>");
         $("#code_column").append(stepWidgets);
     }
 
@@ -361,9 +361,23 @@ var stepContent = (function() {
     }
   };
 
-  // Update widgets displayed on right-hand side of multipane layout for the specified id.
+  /* 
+   * Update widgets displayed on right-hand side of multipane layout for the specified id.
+   * 
+   * id - the ID (hash value without the '#') for the given step.
+   */
   var showStepWidgets = function(id) {
     console.log("show widgets for step " + id);
+    if (window.innerWidth >= twoColumnBreakpoint) {
+      // Find the stepName based on the ID
+      var stepName = getStepNameFromHash(id);
+      
+      // #codeColumn is showing.   Only display applicable widgets for the step.
+      $('.multicolStepShown').removeClass('multicolStepShown').addClass('multicolStepHidden');
+      // Find the .stepWidgetContainer holding the widgets for the specified step.
+      var $selectedStepContainer =  $('.stepWidgetContainer[data-step=' + stepName + ']');
+      $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');
+    } 
   };
 
   var createWidget = function(stepName, content, displayType, subContainer, displayTypeNum) {

--- a/js/interactive-guides/table-of-contents.js
+++ b/js/interactive-guides/table-of-contents.js
@@ -59,8 +59,9 @@ var tableofcontents = (function() {
         $("#toc_container li").on('click', function(event) {
           // 'this' is the li element in the #toc_container.
           TOCEntryClick(this, event);
-
           var hash = window.location.hash.substring(1);  // Remove the '#'
+          // Match the widgets on the right to the new id
+          stepContent.showStepWidgets(hash);
           stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash));
         }); 
     };


### PR DESCRIPTION
When the user is viewing the guide in two or three column multipane layout, switch the widgets shown in the right column based on the selected steps.

Changes made:
 - Switched step-content.css to step-content.scss to allow for the new CSS formatting.
 - **step-content.scss**:  defined two new CSS classes, multicolStepHidden and multicolStepShown, for hiding and displaying the appropriate .stepWidgetContainer div based on the currently selected (or scrolled into view) step.  The div's only need to be managed when in two or three column view when the #code_column is displayed.
 - **step-content.js**:  Created showStepWidgets(id) to show the widgets belonging to the specified step id.  The steps not currently shown are given the multicolStepHidden class; those shown are given the mulicolStepShown class.
 - **blueprint.js**: Call stepContent.showStepWidgets(id) when the user starts the guide with a hashed step URL, or when scrolling as the section's change.
 - **table-of-contents.js**: Call stepContent.showStepWidgets(id) when a TOC entry is selected.


