### PR TITLE
Add code for handling widget swapping between single/multi pane view

### DIFF
--- a/css/interactive-guides/main.scss
+++ b/css/interactive-guides/main.scss
@@ -138,6 +138,12 @@ instruction.unavailable {
   text-align:left;
 }
 
+.stepWidgetContainer {
+    @media (max-width: 1170px) {
+        overflow: auto;
+    }
+}
+
 samp {
   font-size:13px;
   padding: 9.5px;

--- a/css/interactive-guides/step-content.scss
+++ b/css/interactive-guides/step-content.scss
@@ -16,6 +16,10 @@
 
 .disableContainer {
   opacity: 0.5;
+
+  @media (max-width: 1170px) {
+      display: none;
+  }
 }
 
 .multicolStepShown {

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -1,12 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation
+ *******************************************************************************/
 var currentView;
 var widgetDivs;
 function init() {
-    if (document.body.scrollWidth <= 1170) {
+    widgetDivs = $('.stepWidgetContainer');
+    if (window.innerWidth <= 1170) {
         currentView = 'single';
-        widgetDivs = $('.stepWidgetContainer');
     } else {
         currentView = 'multi';
-        widgetDivs = $('.stepWidgetContainer');
     }
 }
 
@@ -24,11 +33,11 @@ $(window).on('load', function() {
             currentView = 'single';
             console.log('Switch to single column at ', window.innerWidth);
 
+            // JQuery's detach() method returns a NodeList which is tricky to iterate over
             var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-            widgetDivsArray.map(widget => {
+            widgetDivsArray.map(function(widget) {
                 var step = widget.dataset.step;
-                //alternatively, $("#contentContainer .sect1#" + step + "_content")[0];
-                var contentStepDiv = $("#contentContainer .sect1:has(div[data-step='" + step + "'])")[0];
+                var contentStepDiv = $('#contentContainer #' + step + '_content')[0];
                 contentStepDiv.appendChild(widget);
             });
         } else if (currentView == 'single' && window.innerWidth > 1170) {
@@ -37,9 +46,8 @@ $(window).on('load', function() {
             console.log('Switch to multi column at ', window.innerWidth);
 
             var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-            widgetDivsArray.map(widget => {
-                var step = widget.dataset.step;
-                var codeColumnDiv = $("#code_column")[0];
+            var codeColumnDiv = $('#code_column')[0];
+            widgetDivsArray.map(function(widget) {
                 codeColumnDiv.appendChild(widget);
             });
         } else {

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -16,6 +16,7 @@ function init() {
 
     if (inSingleColumnView()) {
         currentView = 'single';
+        multiToSingleColumn();
     } else {
         currentView = 'multi';
     }

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -19,10 +19,10 @@ $(window).on('load', function() {
     //TODO: when switching to multi, determine what step is selected 
     // and show correct widgets (iguides-common PR #185)
     $(window).on('resize', function() {
-        if (currentView == 'multi' && document.body.scrollWidth <= 1170) {
+        if (currentView == 'multi' && window.innerWidth <= 1170) {
             // move widgets to single column
             currentView = 'single';
-            console.log('Switch to single column');
+            console.log('Switch to single column at ', window.innerWidth);
 
             var widgetDivsArray = [].slice.call( widgetDivs.detach() );
             widgetDivsArray.map(widget => {
@@ -31,10 +31,10 @@ $(window).on('load', function() {
                 var contentStepDiv = $("#contentContainer .sect1:has(div[data-step='" + step + "'])")[0];
                 contentStepDiv.appendChild(widget);
             });
-        } else if (currentView == 'single' && document.body.scrollWidth > 1170) {
+        } else if (currentView == 'single' && window.innerWidth > 1170) {
             // move widgets to right column
             currentView = 'multi';
-            console.log('Switch to multi column');
+            console.log('Switch to multi column at ', window.innerWidth);
 
             var widgetDivsArray = [].slice.call( widgetDivs.detach() );
             widgetDivsArray.map(widget => {
@@ -42,7 +42,6 @@ $(window).on('load', function() {
                 var codeColumnDiv = $("#code_column")[0];
                 codeColumnDiv.appendChild(widget);
             });
-
         } else {
             //Do nothing
         }

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -1,0 +1,50 @@
+var currentView;
+var widgetDivs;
+function init() {
+    if (document.body.scrollWidth <= 1170) {
+        currentView = 'single';
+        widgetDivs = $('.stepWidgetContainer');
+    } else {
+        currentView = 'multi';
+        widgetDivs = $('.stepWidgetContainer');
+    }
+}
+
+//TODO: functions for getting (and setting) single/multi pane var?
+//      to be used in other areas of multipane code
+
+$(window).on('load', function() {
+    init();
+
+    //TODO: when switching to multi, determine what step is selected 
+    // and show correct widgets (iguides-common PR #185)
+    $(window).on('resize', function() {
+        if (currentView == 'multi' && document.body.scrollWidth <= 1170) {
+            // move widgets to single column
+            currentView = 'single';
+            console.log('Switch to single column');
+
+            var widgetDivsArray = [].slice.call( widgetDivs.detach() );
+            widgetDivsArray.map(widget => {
+                var step = widget.dataset.step;
+                //alternatively, $("#contentContainer .sect1#" + step + "_content")[0];
+                var contentStepDiv = $("#contentContainer .sect1:has(div[data-step='" + step + "'])")[0];
+                contentStepDiv.appendChild(widget);
+            });
+        } else if (currentView == 'single' && document.body.scrollWidth > 1170) {
+            // move widgets to right column
+            currentView = 'multi';
+            console.log('Switch to multi column');
+
+            var widgetDivsArray = [].slice.call( widgetDivs.detach() );
+            widgetDivsArray.map(widget => {
+                var step = widget.dataset.step;
+                var codeColumnDiv = $("#code_column")[0];
+                codeColumnDiv.appendChild(widget);
+            });
+
+        } else {
+            //Do nothing
+        }
+    });
+});

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -9,18 +9,38 @@
  *     IBM Corporation
  *******************************************************************************/
 var currentView;
-var widgetDivs;
+var widgetDivs, codeColumnDiv;
 function init() {
     widgetDivs = $('.stepWidgetContainer');
-    if (window.innerWidth <= 1170) {
+    codeColumnDiv = $('#code_column')[0];
+
+    if (inSingleColumnView()) {
         currentView = 'single';
     } else {
         currentView = 'multi';
     }
 }
 
-//TODO: functions for getting (and setting) single/multi pane var?
-//      to be used in other areas of multipane code
+function multiToSingleColumn() {
+    currentView = 'single';
+
+    // JQuery's detach() method returns a NodeList which is tricky to iterate over
+    var widgetDivsArray = [].slice.call( widgetDivs.detach() );
+    widgetDivsArray.map(function(widget) {
+        var step = widget.dataset.step;
+        var contentStepDiv = $('#contentContainer #' + step + '_content')[0];
+        contentStepDiv.appendChild(widget);
+    });
+}
+
+function singleToMultiColumn() {
+    currentView = 'multi';
+
+    var widgetDivsArray = [].slice.call( widgetDivs.detach() );
+    widgetDivsArray.map(function(widget) {
+        codeColumnDiv.appendChild(widget);
+    });
+}
 
 $(window).on('load', function() {
     init();
@@ -28,30 +48,10 @@ $(window).on('load', function() {
     //TODO: when switching to multi, determine what step is selected 
     // and show correct widgets (iguides-common PR #185)
     $(window).on('resize', function() {
-        if (currentView == 'multi' && window.innerWidth <= 1170) {
-            // move widgets to single column
-            currentView = 'single';
-            console.log('Switch to single column at ', window.innerWidth);
-
-            // JQuery's detach() method returns a NodeList which is tricky to iterate over
-            var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-            widgetDivsArray.map(function(widget) {
-                var step = widget.dataset.step;
-                var contentStepDiv = $('#contentContainer #' + step + '_content')[0];
-                contentStepDiv.appendChild(widget);
-            });
-        } else if (currentView == 'single' && window.innerWidth > 1170) {
-            // move widgets to right column
-            currentView = 'multi';
-            console.log('Switch to multi column at ', window.innerWidth);
-
-            var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-            var codeColumnDiv = $('#code_column')[0];
-            widgetDivsArray.map(function(widget) {
-                codeColumnDiv.appendChild(widget);
-            });
-        } else {
-            //Do nothing
+        if (currentView == 'multi' && inSingleColumnView()) {
+            multiToSingleColumn();
+        } else if (currentView == 'single' && !inSingleColumnView()) {
+            singleToMultiColumn();
         }
     });
 });

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -12,7 +12,7 @@ var currentView;
 var widgetDivs, codeColumnDiv;
 function init() {
     widgetDivs = $('.stepWidgetContainer');
-    codeColumnDiv = $('#code_column')[0];
+    codeColumnDiv = $('#code_column');
 
     if (inSingleColumnView()) {
         currentView = 'single';
@@ -29,8 +29,14 @@ function multiToSingleColumn() {
     var widgetDivsArray = [].slice.call( widgetDivs.detach() );
     widgetDivsArray.map(function(widget) {
         var step = widget.dataset.step;
-        var contentStepDiv = $('#contentContainer #' + step + '_content')[0];
-        contentStepDiv.appendChild(widget);
+        var contentStepDiv = $('#contentContainer #' + step + '_content');
+
+        var subsection = contentStepDiv.find('.sect2');
+        if (subsection.length > 0) {
+            subsection.before(widget);
+        } else {
+            contentStepDiv.append(widget);
+        }
     });
 }
 
@@ -39,7 +45,7 @@ function singleToMultiColumn() {
 
     var widgetDivsArray = [].slice.call( widgetDivs.detach() );
     widgetDivsArray.map(function(widget) {
-        codeColumnDiv.appendChild(widget);
+        codeColumnDiv.append(widget);
     });
 }
 


### PR DESCRIPTION
Able to switch widgets between single and multi pane view. Initialization works in both single and multi pane view.

`step-content.js` needs to be updated to load the widgets in the single column view, currently only puts widgets in the right-side pane which is invisible in the multi pane view.

**To Enable**: In a guide's main html, add `- interactive-guides/iguide-multipane` under the js imports.
Issue for enabling in circuit breaker guide: OpenLiberty/iguide-circuit-breaker#134