### PR TITLE
setCurrentStepName during scrolling updates

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -116,11 +116,11 @@ var blueprint = (function(){
           history.pushState(null, null, newPath);
 
           // Update the selected TOC entry
-          updateTOCHighlighting(id);
-
-          // Match the widgets on the right to the new id
-          stepContent.showStepWidgets(id);
+          updateTOCHighlighting(id);  // In toc-multipane.js in openliberty.io
         }
+        // Match the widgets on the right to the new id
+        stepContent.showStepWidgets(id);
+        stepContent.setCurrentStepName(id);
       }
     }
   };


### PR DESCRIPTION
During scrolling updates, when switching from one step to another, set the current step name in stepContent.  Many of the current interactive guides rely on this setting.