### PR TITLE
Multicolumn format: Check if in metadata before assigning steps widgets

### DIFF
--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -375,7 +375,7 @@ var stepContent = (function() {
       $('.multicolStepShown').removeClass('multicolStepShown').addClass('multicolStepHidden');
 
       // stepName is "" when srollTop displays guide header, or guide meta.
-      if (stepName !== "") {
+      if (stepName) {
         // Find the .stepWidgetContainer holding the widgets for the specified step.
         var $selectedStepContainer =  $('.stepWidgetContainer[data-step=' + stepName + ']');
         $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -367,16 +367,19 @@ var stepContent = (function() {
    * id - the ID (hash value without the '#') for the given step.
    */
   var showStepWidgets = function(id) {
-    console.log("show widgets for step " + id);
     if (window.innerWidth >= twoColumnBreakpoint) {
       // Find the stepName based on the ID
       var stepName = getStepNameFromHash(id);
       
       // #codeColumn is showing.   Only display applicable widgets for the step.
       $('.multicolStepShown').removeClass('multicolStepShown').addClass('multicolStepHidden');
-      // Find the .stepWidgetContainer holding the widgets for the specified step.
-      var $selectedStepContainer =  $('.stepWidgetContainer[data-step=' + stepName + ']');
-      $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');
+
+      // stepName is "" when srollTop displays guide header, or guide meta.
+      if (stepName !== "") {
+        // Find the .stepWidgetContainer holding the widgets for the specified step.
+        var $selectedStepContainer =  $('.stepWidgetContainer[data-step=' + stepName + ']');
+        $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');
+      }
     } 
   };
 


### PR DESCRIPTION
When scrolling in and out of the meta-data at the top of the guide, while in multi-column format, the console log was showing

Syntax error, unrecognized expression: .stepWidgetContainer[data-step=]

coming from showStepWidgets():379.  Updated showStepWidgets() to allow us to hide guide widgets when we are scrolled into the meta-data at the top of the guide, but won't look to display any other widgets since at this point we aren't on a particular step.  The design is not specific about what we should show at this point, so implementing this way.