### PR TITLE
Made changes to instruction styling for single column view

### DIFF
--- a/css/interactive-guides/main.css
+++ b/css/interactive-guides/main.css
@@ -63,6 +63,12 @@
   border-left: 4px solid #96bc32;
 }
 
+@media (max-width: 1170px){
+  instruction.unavailable {
+    display: none;
+  }
+}
+
 action.disabled {
   color: red;
 }

--- a/js/interactive-guides/modules/content-manager.js
+++ b/js/interactive-guides/modules/content-manager.js
@@ -731,6 +731,12 @@ var contentManager = (function() {
         if(instruction){
             var instructionID = stepName + '-instruction-' + currentInstructionIndex;
 
+            //scroll so the recently completed instruction is at the top of the browser window
+            if (($("#"+instructionID).length > 0) && (window.innerWidth <= 1170)) {
+              //subtract 40 to consider the TOC button height in single column view
+              $("html, body").animate({ scrollTop: ($("#"+instructionID).offset().top - 40)}, 750);
+            }
+
             if(instruction.complete === false){
                 instruction.complete = true;
                 $("#"+instructionID).addClass("completed");

--- a/js/interactive-guides/modules/content-manager.js
+++ b/js/interactive-guides/modules/content-manager.js
@@ -732,7 +732,7 @@ var contentManager = (function() {
             var instructionID = stepName + '-instruction-' + currentInstructionIndex;
 
             //scroll so the recently completed instruction is at the top of the browser window
-            if (($("#"+instructionID).length > 0) && (window.innerWidth <= 1170)) {
+            if (($("#"+instructionID).length > 0) && (window.innerWidth <= twoColumnBreakpoint)) {
               //subtract 40 to consider the TOC button height in single column view
               $("html, body").animate({ scrollTop: ($("#"+instructionID).offset().top - 40)}, 750);
             }


### PR DESCRIPTION
Changes made:
- **main.css:** Made changes to display only completed instructions and the one currently being worked on should be shown in single column view
- **content-manager.js:** When enabling the next instruction, scroll up slightly as you enable it so that it sits at the top of the browser page