### PR TITLE
Switch sections when scrolling in single column

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -50,7 +50,7 @@ var blueprint = (function(){
             if($("body").data('scrolling') === true) {
                 return;
             }
-            handleSectionSnapping(event);
+            handleSectionChanging(event);
           });
     });    
   };
@@ -98,30 +98,33 @@ var blueprint = (function(){
     }
   };
 
-  var handleSectionSnapping = function(event) {
-    // Multipane view
-    if(window.innerWidth > twoColumnBreakpoint) {
-      var id = getScrolledVisibleSectionID();
-      if (id !== null) {
-        var windowHash = window.location.hash;
-        var scrolledToHash = id === "" ? id : '#' + id;
-        if (windowHash !== scrolledToHash) {
-          // Update the URL hash with new section we scrolled into....
-          var currentPath = window.location.pathname;
-          var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
-          // Not setting window.location.hash here because that causes an
-          // onHashChange event to fire which will scroll to the top of the
-          // section.  pushState updates the URL without causing an
-          // onHashChange event.
-          history.pushState(null, null, newPath);
+  var handleSectionChanging = function(event) {
+    // Get the id of the section most in view
+    var id = getScrolledVisibleSectionID();
 
-          // Update the selected TOC entry
-          updateTOCHighlighting(id);  // In toc-multipane.js in openliberty.io
-        }
-        // Match the widgets on the right to the new id
-        stepContent.showStepWidgets(id);
-        stepContent.setCurrentStepName(id);
+    if (id !== null) {
+      var windowHash = window.location.hash;
+      var scrolledToHash = id === "" ? id : '#' + id;
+      if (windowHash !== scrolledToHash) {
+        // Update the URL hash with new section we scrolled into....
+        var currentPath = window.location.pathname;
+        var newPath = currentPath.substring(currentPath.lastIndexOf('/')+1) + scrolledToHash;
+        // Not setting window.location.hash here because that causes an
+        // onHashChange event to fire which will scroll to the top of the
+        // section.  pushState updates the URL without causing an
+        // onHashChange event.
+        history.pushState(null, null, newPath);
+
+        // Update the selected TOC entry
+        updateTOCHighlighting(id);  // In toc-multipane.js in openliberty.io
       }
+      stepContent.setCurrentStepName(id);
+    }
+    
+    if(window.innerWidth > twoColumnBreakpoint) {
+      // Multipane view
+      // Match the widgets on the right to the new id
+      stepContent.showStepWidgets(id);
     }
   };
 

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -21,7 +21,6 @@ var stepContent = (function() {
   var setSteps = function(steps, defaultWidgets) {
     _steps = steps;
     _defaultWidgets = defaultWidgets;
-    console.log("defaultWidgets ", _defaultWidgets);
     __createLinks();
   };
 
@@ -84,7 +83,7 @@ var stepContent = (function() {
     return currentStepName;
   };
 
-  var setCurrentStepName = function(stepName) {
+  var setCurrentStepName = function(stepName) {    
     currentStepName = stepName;   
   }
 


### PR DESCRIPTION
Enable section switching when in single column mode.  Update the hash as you scroll through the sections in single column mode. We decided that in single column mode the hash should change as the section header (h2 or h3) reaches the TOC header. This also helps with small sections being identified since we don't have to worry about them never getting the majority of the vertical space. In multi-column mode, the hash changes as a section takes over the majority of the screen space.