### PR TITLE
First pass at fixing widgets css to fit in new guide layout

### DIFF
--- a/css/interactive-guides/bankApp.css
+++ b/css/interactive-guides/bankApp.css
@@ -23,7 +23,7 @@ body {
 
 .bankHeading {
     font-weight: 500;
-    font-size: 16px;
+    font-size: 14px;
     color: #343334;
     letter-spacing: 0;
     text-align: left;
@@ -37,7 +37,7 @@ body {
 }
 
 .stepIntroText {
-    font-size: 16px;
+    font-size: 14px;
     color: #272727;
     letter-spacing: 0;
     text-align: left;
@@ -74,8 +74,8 @@ body {
 
 .flexWarningContainer > div {
     text-align: center;
-    line-height: 26px;
-    font-size: 16px;
+    line-height: 24px;
+    font-size: 14px;
     align-self: center;
     color: #272727;
     letter-spacing: 0;

--- a/css/interactive-guides/main.scss
+++ b/css/interactive-guides/main.scss
@@ -124,12 +124,6 @@ instruction.unavailable {
   pointer-events: none;
 }
 
-.podContainer {
-  /*padding-bottom: 30px;*/
-  border: 1px solid #c8d6fb;
-  height: 200px;
-}
-
 .instructionContent {
   padding-left: 11px;
   color:#1b1c34;

--- a/css/interactive-guides/pod.scss
+++ b/css/interactive-guides/pod.scss
@@ -8,12 +8,27 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
+
+.podContainer {
+  height: auto;
+  @media (min-width: 1170px) {
+    border: 1px solid #c8d6fb;
+    background: rgba(255,255,255,0.75);
+    height: 200px;    
+  }
+
+  p {
+    font-size: 14px;
+  }
+}
+
 .pod-animation-slide-from-right {
   position: relative;
   -webkit-animation-name: animate-slide-from-right;
   -webkit-animation-duration: 1s;
   animation-name: animate-slide-from-right;
-  animation-duration: 1s
+  animation-duration: 1s;
+  height: inherit;
 }
 
 .pod-animation-slide-from-right:focus {

--- a/css/interactive-guides/step-content.scss
+++ b/css/interactive-guides/step-content.scss
@@ -11,7 +11,11 @@
 .subContainerDiv {
   padding: 0px 5px;
   margin-bottom: 2.5px;
-  margin-top: 2.5px;  
+  margin-top: 2.5px; 
+  
+  @media (max-width: 1170px) {
+    margin: 10px 0px;
+  }
 }
 
 .disableContainer {
@@ -31,12 +35,6 @@
 
   @media (max-width: 1170px) {
     display: block;
-  }
-}
-
-@media (max-width: 450px) {
-  .subContainerDiv {
-    margin-bottom: 60px;
   }
 }
 

--- a/css/interactive-guides/web-browser.scss
+++ b/css/interactive-guides/web-browser.scss
@@ -14,10 +14,9 @@
 
 .wbNavBar {
     background-color: #5e6b8d;
-    height: 50px;
     width: 100%;
     color: lightsteelblue;
-    padding: 10px;
+    padding: 6px;
     overflow-x: hidden;
     white-space: nowrap;
 }
@@ -35,8 +34,8 @@
 }
 
 .wbNavButton {
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
     display: inline-block;
     background-repeat: no-repeat;
     position: relative;
@@ -79,6 +78,9 @@
 
 .wbContent {
     height: 85%;
+    @media (max-width: 1170px) {
+        height: 300px;
+    }
 }
 
 .wbOverlay:after {

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -269,6 +269,9 @@ var stepContent = (function() {
         var columnHeight = rightColumn.height();
         var wHeight = (columnHeight * percentageHeight)/100;
         widgetHeight = wHeight + "px";
+    } else {
+      // Don't dictate the height in single column mode.
+      widgetHeight = "auto";
     }
     return widgetHeight;
   }


### PR DESCRIPTION
**bankApp.css**
- Fix fonts used in the bank app 

**main.css**
- move definition for .podContainer to pod.css

**pod.css** ---> renamed to **pod.scss**
- Added .podContainer definition
- Added 'height: inherit' to definition for .pod-animation-slide-from-right so the widgets contained in the sliding pod would have a height defined to base their sizing on.

**step-content.scss** 
- Changes for single column view of the new guides

**web-browser.scss**
- Changes to the header of the web-browser widget to make it more compact and match the design.

**step-content.js**
- Update to calculateWidgetHeight() to allow widgets to size more appropriately in single column view.