### PR TITLE
Update iguide-multipane.js to not rely on onload

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -18,6 +18,7 @@ var blueprint = (function(){
           stepContent.setSteps(steps, defaultWidgets, configWidgets);
           tableofcontents.create(steps);
           stepContent.createGuideContents();
+          iguideMultipane.initView();
       
           // Monitor for hash changes to show the requested page.
           // Hash changes occur when the URL is updated with a new hash

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -8,57 +8,72 @@
  * Contributors:
  *     IBM Corporation
  *******************************************************************************/
-var currentView;
-var widgetDivs, codeColumnDiv;
-function init() {
-    widgetDivs = $('.stepWidgetContainer');
-    codeColumnDiv = $('#code_column');
+var iguideMultipane = (function() {
+    "use strict";
 
-    if (inSingleColumnView()) {
-        currentView = 'single';
-        multiToSingleColumn();
-    } else {
-        currentView = 'multi';
-    }
-}
+    var currentView;  // value is "single" or "multi"
+    var widgetDivs, codeColumnDiv;
 
-function multiToSingleColumn() {
-    currentView = 'single';
-
-    // JQuery's detach() method returns a NodeList which is tricky to iterate over
-    var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-    widgetDivsArray.map(function(widget) {
-        var step = widget.dataset.step;
-        var contentStepDiv = $('#contentContainer #' + step + '_content');
-
-        var subsection = contentStepDiv.find('.sect2');
-        if (subsection.length > 0) {
-            subsection.before(widget);
-        } else {
-            contentStepDiv.append(widget);
-        }
-    });
-}
-
-function singleToMultiColumn() {
-    currentView = 'multi';
-
-    var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-    widgetDivsArray.map(function(widget) {
-        codeColumnDiv.append(widget);
-    });
-}
-
-$(window).on('load', function() {
-    init();
-
-    //TODO: when switching to multi, determine what step is selected 
-    // and show correct widgets (iguides-common PR #185)
-    $(window).on('resize', function() {
-        if (currentView == 'multi' && inSingleColumnView()) {
+    var initView = function() {
+        widgetDivs = $('.stepWidgetContainer');
+        codeColumnDiv = $('#code_column');
+    
+        if (inSingleColumnView()) {
+            currentView = 'single';
             multiToSingleColumn();
+        } else {
+            currentView = 'multi';
+        }
+    };
+
+    var getCurrentViewType = function() {
+        return currentView;
+    };
+    
+    var multiToSingleColumn =  function() {
+        currentView = 'single';
+    
+        // JQuery's detach() method returns a NodeList which is tricky to iterate over
+        var widgetDivsArray = [].slice.call( widgetDivs.detach() );
+        widgetDivsArray.map(function(widget) {
+            var step = widget.dataset.step;
+            var contentStepDiv = $('#contentContainer #' + step + '_content');
+    
+            var subsection = contentStepDiv.find('.sect2');
+            if (subsection.length > 0) {
+                subsection.before(widget);
+            } else {
+                contentStepDiv.append(widget);
+            }
+        });
+    };
+    
+    var singleToMultiColumn = function() {
+        currentView = 'multi';
+    
+        var widgetDivsArray = [].slice.call( widgetDivs.detach() );
+        widgetDivsArray.map(function(widget) {
+            codeColumnDiv.append(widget);
+        });
+    };
+
+    return {
+        initView: initView,
+        getCurrentViewType: getCurrentViewType,
+        multiToSingleColumn: multiToSingleColumn,
+        singleToMultiColumn: singleToMultiColumn
+      };
+})();
+
+
+$(document).ready(function() {
+
+    $(window).on('resize', function() {
+        var currentView = iguideMultipane.getCurrentViewType();
+        if (currentView == 'multi' && inSingleColumnView()) {
+            iguideMultipane.multiToSingleColumn();
         } else if (currentView == 'single' && !inSingleColumnView()) {
-            singleToMultiColumn();
+            iguideMultipane.singleToMultiColumn();
         }
     });
 });


### PR DESCRIPTION
In single-view of the interactive guides new multipane design, the widgets for each of the steps were not showing up.  The reason was that the new iguide-multipane.js initialized the current view of the guide within an on load method ( $(window).on('load', function() {....}  ).
However the $('.stepWidgetContainer')s had not been created when the code in the init() executed and therefore the variables that handle the widget movement were never initialized correctly.

I restructured the code to add the resize request during document.ready instead and invoked the init method for iguide-multipane from the original on load method for the interactive guides, which is in blueprint.js.

