### PR TITLE
Fix the code column height and editor height issues

### DIFF
--- a/css/interactive-guides/editor.scss
+++ b/css/interactive-guides/editor.scss
@@ -17,13 +17,13 @@
   line-height: 21px;
   text-align: left;
   background-color: #f1f4fe; 
-  height: 375px;
+  height: 100%;
   @media (max-width: 1170px) {
     height: 300px;    
   }
 }
 
-.codeeditor {
+.codeeditor, .editorContainer {
   height: 100%; 
 }
 

--- a/css/interactive-guides/tabbed-editor.css
+++ b/css/interactive-guides/tabbed-editor.css
@@ -77,3 +77,7 @@
 .teContents {
     clear: left;    /* Clear the float from the tab <li> elements */
 }
+
+.teContainer, .teContents, .teTabContent {
+    height: 100%
+}

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -313,7 +313,12 @@ var stepContent = (function() {
         
     var rightColumn = $("#code_column:visible");
     if (rightColumn.length > 0) {
-        // Get height of visible right column
+        // Recalculate the height of visible right column
+        var windowHeight = window.innerHeight;
+        var endOfGuideTopPosition = $("#end_of_guide")[0].getBoundingClientRect().top;
+        if (endOfGuideTopPosition > windowHeight) {
+          $("#code_column").css('bottom', '0');
+        }
         var columnHeight = rightColumn.height();
         if (numOfWidgets === 3) {
           if (isPodHidden === true) {


### PR DESCRIPTION
PR contains the following 2 fixes:
- When the code column contains 3 widgets, the overall height of the code column could be messed up and set to a height less than the view port. 
- Remove the fixed height in the editor