### PR TITLE
Changes to support single to multi column view and vice versa

### DIFF
--- a/css/interactive-guides/editor.scss
+++ b/css/interactive-guides/editor.scss
@@ -18,9 +18,6 @@
   text-align: left;
   background-color: #f1f4fe; 
   height: 100%;
-  @media (max-width: 1170px) {
-    height: 300px;    
-  }
 }
 
 .editorContainer {

--- a/css/interactive-guides/web-browser.scss
+++ b/css/interactive-guides/web-browser.scss
@@ -78,9 +78,6 @@
 
 .wbContent {
     height: calc( 100% - 60px ); /* 60px = wbNavBar + wbStatusBar */
-    @media (max-width: 1170px) {
-        height: 300px;
-    }
 }
 
 .wbOverlay:after {

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -8,16 +8,16 @@
  * Contributors:
  *     IBM Corporation
  *******************************************************************************/
-var iguideMultipane = (function() {
+var iguideMultipane = (function () {
     "use strict";
 
     var currentView;  // value is "single" or "multi"
     var widgetDivs, codeColumnDiv;
 
-    var initView = function() {
+    var initView = function () {
         widgetDivs = $('.stepWidgetContainer');
         codeColumnDiv = $('#code_column');
-    
+
         if (inSingleColumnView()) {
             currentView = 'single';
             multiToSingleColumn();
@@ -26,35 +26,115 @@ var iguideMultipane = (function() {
         }
     };
 
-    var getCurrentViewType = function() {
+    var getCurrentViewType = function () {
         return currentView;
     };
-    
-    var multiToSingleColumn =  function() {
+
+    var multiToSingleColumn = function () {
         currentView = 'single';
-    
+
         // JQuery's detach() method returns a NodeList which is tricky to iterate over
-        var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-        widgetDivsArray.map(function(widget) {
+        var widgetDivsArray = [].slice.call(widgetDivs.detach());
+        widgetDivsArray.map(function (widget) {
             var step = widget.dataset.step;
             var contentStepDiv = $('#contentContainer #' + step + '_content');
-    
+
             var subsection = contentStepDiv.find('.sect2');
             if (subsection.length > 0) {
                 subsection.before(widget);
             } else {
                 contentStepDiv.append(widget);
+
+                // adjust the editpr position and height of the widgets in the code_column
+                setTabbedEditorPosition(contentStepDiv.find('.stepWidgetContainer[data-step="' + step + '"]'), step);
+                adjustBrowserHeight(contentStepDiv.find('#' + step + '-webBrowser-0'));
+                adjustTabbedEditorHeight(contentStepDiv.find('#' + step + '-tabbedEditor-0'));
+                adjustPodHeight(contentStepDiv.find('#' + step + '-pod-0'));
             }
         });
     };
-    
-    var singleToMultiColumn = function() {
+
+    var singleToMultiColumn = function () {
         currentView = 'multi';
-    
-        var widgetDivsArray = [].slice.call( widgetDivs.detach() );
-        widgetDivsArray.map(function(widget) {
+
+        var widgetDivsArray = [].slice.call(widgetDivs.detach());
+        widgetDivsArray.map(function (widget) {
             codeColumnDiv.append(widget);
+
+            // adjust the editpr position and height of the widgets in the code_column
+            widget = $(widget);
+            var step = widget.attr('data-step');
+            setTabbedEditorPosition(widget, step);
+            var podHeight = adjustPodHeight(widget.find('#' + step + '-pod-0'));
+            var BrowserHeight = adjustBrowserHeight(widget.find('#' + step + '-webBrowser-0'), widget.children().length);
+            adjustTabbedEditorHeight(widget.find('#' + step + '-tabbedEditor-0'), podHeight + BrowserHeight);
         });
+    };
+
+    var setTabbedEditorPosition = function (stepWidgetContainer, step) {
+        if (stepWidgetContainer.length > 0) {
+            var tabbedEditorWidget = stepWidgetContainer.find('#' + step + '-tabbedEditor-0');
+            if (tabbedEditorWidget.length > 0) {
+                if (currentView === 'multi') {
+                    tabbedEditorWidget.detach();
+                    stepWidgetContainer.append(tabbedEditorWidget);
+                } else {
+                    tabbedEditorWidget.detach();
+                    stepWidgetContainer.prepend(tabbedEditorWidget);
+                }
+            }
+        }
+    };
+
+    var adjustPodHeight = function (pod) {
+        var height = 150;
+        if (pod.length > 0) {
+            if (currentView === 'single') {
+                pod.css('height', 'auto');
+            } else {
+                pod.css('height', height + 'px');
+            }
+        } else {
+            height = 0;
+        }
+        return height;
+    };
+
+    var adjustBrowserHeight = function (browser, numOfWidgets) {
+        var height = 300;
+        if (browser.length > 0) {
+            if (currentView === 'single') {
+                var balanceContainer = browser.find('.wbContent').find('iframe').contents().find('div.checkBalanceContainer');                
+                // One will think that checkBalanceContainer may not be there depending on the step progress.
+                // However, neither checkBalanceContainer nor flexWarningContainer selector was returned.
+                // As a result the height for browser is always 300 in single column view.
+                if (balanceContainer.length > 0) {
+                    height = balanceContainer.height() + 126;
+                } 
+            } else {
+                if (browser.hasClass('disableContainer') && (numOfWidgets > 2)) {
+                    height = 200;
+                }               
+            }
+            browser.css('height', height + 'px');
+        } else {
+            height = 0;
+        }
+        return height;
+    };
+
+    var adjustTabbedEditorHeight = function (tabbedEditor, otherWidgetHeight) {
+        if (tabbedEditor.length > 0) {
+            if (currentView === 'single') {
+                tabbedEditor.css('height', 'auto');
+            } else {
+                // not able to use $('#code_column').height() as it may get 0 during resizing
+                var codeColumnHeight = window.innerHeight - 101; // not able to use $('.navbar').height() as the navbar height changes
+                var tabbedEditorHeight = codeColumnHeight - otherWidgetHeight;
+                console.log("code_height = " + codeColumnHeight + "; tabbedEditorHeight = " + tabbedEditorHeight);
+                tabbedEditor.css('height', tabbedEditorHeight + 'px');
+            }
+        }
     };
 
     return {
@@ -62,13 +142,13 @@ var iguideMultipane = (function() {
         getCurrentViewType: getCurrentViewType,
         multiToSingleColumn: multiToSingleColumn,
         singleToMultiColumn: singleToMultiColumn
-      };
+    };
 })();
 
 
-$(document).ready(function() {
+$(document).ready(function () {
 
-    $(window).on('resize', function() {
+    $(window).on('resize', function () {
         var currentView = iguideMultipane.getCurrentViewType();
         if (currentView == 'multi' && inSingleColumnView()) {
             iguideMultipane.multiToSingleColumn();

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -578,8 +578,10 @@ var stepContent = (function() {
 
                 __createWidget(step.name, content, content.displayType, subContainer, displayTypeNum);
 
-                // only handle this in multi view column
-                if (!inSingleColumnView()) {
+                // Cannot just handle this in multi view column. When it is resized, need to handle click too.
+                // Enable the click listener all the times for now. Will refactor the codes here so that
+                // it could be called in initial build content + during resize from single to multi pane.
+                //if (!inSingleColumnView()) {
                   // hide the widget if it's hidden
                   var isWidgetHidden = widgetsObjInfo[index].hidden;
                   if (isWidgetHidden === true) {
@@ -624,7 +626,7 @@ var stepContent = (function() {
                       });
                     }
                   }
-                }
+                //}
             }
       });
     } else {


### PR DESCRIPTION
Initial drop to support resizing causing the interactive guide to change from single to multi column view and vice versa. When switching from single to multi column view, since there is no indicator on which widget in the code column should be the active/focus one, no widget is given the active state at the moment.