### PR TITLE
Various changes to resizing affecting the code column

### DIFF
--- a/css/interactive-guides/step-content.scss
+++ b/css/interactive-guides/step-content.scss
@@ -14,7 +14,7 @@
 
 .stepWidgetOnHover:hover {
   @media (min-width: 1170px) {
-    border: 1px solid rgba(0,0,0,0.5);
+    border: 1px solid #1B1C34;
   }
 }
 
@@ -29,7 +29,7 @@
 }
 
 .disableContainer {
-  opacity: 0.5;
+  opacity: 0.3;
 
   @media (max-width: 1170px) {
       display: none;

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -46,10 +46,10 @@ var iguideMultipane = (function () {
                 contentStepDiv.append(widget);
 
                 // adjust the editpr position and height of the widgets in the code_column
-                setTabbedEditorPosition(contentStepDiv.find('.stepWidgetContainer[data-step="' + step + '"]'), step);
-                adjustBrowserHeight(contentStepDiv.find('#' + step + '-webBrowser-0'));
-                adjustTabbedEditorHeight(contentStepDiv.find('#' + step + '-tabbedEditor-0'));
-                adjustPodHeight(contentStepDiv.find('#' + step + '-pod-0'));
+                _setTabbedEditorPosition(contentStepDiv.find('.stepWidgetContainer[data-step="' + step + '"]'), step);
+                _adjustBrowserHeight(contentStepDiv.find('#' + step + '-webBrowser-0'));
+                _adjustTabbedEditorHeight(contentStepDiv.find('#' + step + '-tabbedEditor-0'));
+                _adjustPodHeight(contentStepDiv.find('#' + step + '-pod-0'));
             }
         });
     };
@@ -64,14 +64,14 @@ var iguideMultipane = (function () {
             // adjust the editpr position and height of the widgets in the code_column
             widget = $(widget);
             var step = widget.attr('data-step');
-            setTabbedEditorPosition(widget, step);
-            adjustPodHeight(widget.find('#' + step + '-pod-0'));
-            adjustBrowserHeight(widget.find('#' + step + '-webBrowser-0'), widget.children().length);
+            _setTabbedEditorPosition(widget, step);
+            _adjustPodHeight(widget.find('#' + step + '-pod-0'));
+            _adjustBrowserHeight(widget.find('#' + step + '-webBrowser-0'), widget.children().length);
             _resizeActiveWidget(widget);
         });
     };
 
-    var setTabbedEditorPosition = function (stepWidgetContainer, step) {
+    var _setTabbedEditorPosition = function (stepWidgetContainer, step) {
         if (stepWidgetContainer.length > 0) {
             var tabbedEditorWidget = stepWidgetContainer.find('#' + step + '-tabbedEditor-0');
             if (tabbedEditorWidget.length > 0) {
@@ -86,8 +86,17 @@ var iguideMultipane = (function () {
         }
     };
 
-    var adjustPodHeight = function (pod) {
-        var height = 150;
+    var _getConfigWidgetHeight = function(widgetType) {
+        var height = stepContent.getConfigWidgetHeights()[widgetType];
+        if (height.indexOf('px') !== -1) { 
+            height = height.substring(0, height.indexOf('px'));
+        }
+        height = parseInt(height);
+        return height;
+    }
+
+    var _adjustPodHeight = function (pod) {
+        var height = _getConfigWidgetHeight('pod');
         if (pod.length > 0) {
             if (currentView === 'single') {
                 pod.css('height', 'auto');
@@ -100,8 +109,8 @@ var iguideMultipane = (function () {
         return height;
     };
 
-    var adjustBrowserHeight = function (browser, numOfWidgets) {
-        var height = 300;
+    var _adjustBrowserHeight = function (browser, numOfWidgets) {
+        var height = _getConfigWidgetHeight('webBrowser');
         if (browser.length > 0) {
             if (currentView === 'single') {
                 var balanceContainer = browser.find('.wbContent').find('iframe').contents().find('div.checkBalanceContainer');                
@@ -113,7 +122,7 @@ var iguideMultipane = (function () {
                 } 
             } else {
                 if (browser.hasClass('disableContainer') && (numOfWidgets > 2)) {
-                    height = 200;
+                    height = height - 100;
                 }               
             }
             browser.css('height', height + 'px');
@@ -123,7 +132,7 @@ var iguideMultipane = (function () {
         return height;
     };
 
-    var adjustTabbedEditorHeight = function (tabbedEditor, otherWidgetHeight) {
+    var _adjustTabbedEditorHeight = function (tabbedEditor, otherWidgetHeight) {
         if (tabbedEditor.length > 0) {
             if (currentView === 'single') {
                 if (!tabbedEditor.hasClass('disableContainer')) {
@@ -138,14 +147,12 @@ var iguideMultipane = (function () {
         }
     };
 
-    var resizeCodeColumnHeight = function() {
-        var stepContainers = $('.stepWidgetContainer');
-        if (stepContainers.length > 0) {
-            stepContainers.each(function() {
-                _resizeActiveWidget($(this));
-            })   
+    var resizeCodeColumnHeightInStepShown = function() {
+        var stepContainer = $('.stepWidgetContainer.multicolStepShown');
+        if (stepContainer.length > 0) {
+            _resizeActiveWidget(stepContainer);
         }
-    }
+    };
 
     var _resizeActiveWidget = function(containerWidget) {
         var stepName = containerWidget.attr('data-step');
@@ -155,14 +162,14 @@ var iguideMultipane = (function () {
             activeWidgetType = "webBrowser";
         }
         stepContent.resizeStepWidgets(stepContent.getStepWidgets(stepName), activeWidgetType);
-    }
+    };
 
     return {
         initView: initView,
         getCurrentViewType: getCurrentViewType,
         multiToSingleColumn: multiToSingleColumn,
         singleToMultiColumn: singleToMultiColumn,
-        resizeCodeColumnHeight: resizeCodeColumnHeight
+        resizeCodeColumnHeightInStepShown: resizeCodeColumnHeightInStepShown
     };
 })();
 
@@ -176,7 +183,13 @@ $(document).ready(function () {
         } else if (currentView === 'single' && !inSingleColumnView()) {
             iguideMultipane.singleToMultiColumn();
         } else if (currentView === 'multi' && !inSingleColumnView()) {
-            iguideMultipane.resizeCodeColumnHeight();
+            iguideMultipane.resizeCodeColumnHeightInStepShown();
+        }
+    });
+
+    $(window).on('scroll', function() {
+        if (iguideMultipane.getCurrentViewType() === 'multi') {
+            iguideMultipane.resizeCodeColumnHeightInStepShown();
         }
     });
 });

--- a/js/interactive-guides/iguide-multipane.js
+++ b/js/interactive-guides/iguide-multipane.js
@@ -65,14 +65,9 @@ var iguideMultipane = (function () {
             widget = $(widget);
             var step = widget.attr('data-step');
             setTabbedEditorPosition(widget, step);
-            var webBrowserWidget = widget.find('#' + step + '-webBrowser-0');
             adjustPodHeight(widget.find('#' + step + '-pod-0'));
-            adjustBrowserHeight(webBrowserWidget, widget.children().length);
-            var activeWidgetType = "tabbedEditor";
-            if (webBrowserWidget.hasClass('activeWidget')) {
-                activeWidgetType = "webBrowser";
-            }
-            stepContent.resizeStepWidgets(stepContent.getStepWidgets(step), activeWidgetType);
+            adjustBrowserHeight(widget.find('#' + step + '-webBrowser-0'), widget.children().length);
+            _resizeActiveWidget(widget);
         });
     };
 
@@ -147,17 +142,19 @@ var iguideMultipane = (function () {
         var stepContainers = $('.stepWidgetContainer');
         if (stepContainers.length > 0) {
             stepContainers.each(function() {
-                var stepName = $(this).attr('data-step');
-                var webBrowserWidget = $(this).find('#' + stepName + '-webBrowser-0');
-                var tabbedEditorWidget = $(this).find('#' + stepName + '-tabbedEditor-0');
-
-                var activeWidgetType = "tabbedEditor";
-                if (webBrowserWidget.hasClass('activeWidget')) {
-                    activeWidgetType = "webBrowser";
-                }
-                stepContent.resizeStepWidgets(stepContent.getStepWidgets(stepName), activeWidgetType);
+                _resizeActiveWidget($(this));
             })   
         }
+    }
+
+    var _resizeActiveWidget = function(containerWidget) {
+        var stepName = containerWidget.attr('data-step');
+        var webBrowserWidget = containerWidget.find('#' + stepName + '-webBrowser-0');
+        var activeWidgetType = "tabbedEditor";
+        if (webBrowserWidget.hasClass('activeWidget')) {
+            activeWidgetType = "webBrowser";
+        }
+        stepContent.resizeStepWidgets(stepContent.getStepWidgets(stepName), activeWidgetType);
     }
 
     return {

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -450,47 +450,47 @@ var stepContent = (function() {
       isPodHidden = podWidget.hidden;
     } 
     // readjust the widgets height
-    if (numOfWidgets === 2) {              
-        if (activeWidget === "webBrowser" || activeWidget === "tabbedEditor") {
-          _setWebBrowserAndEditorHeights(activeWidget, numOfWidgets, isPodHidden, editorWidget, browserWidget);
-        } 
+    if (numOfWidgets === 2) {
+      if (activeWidget === "webBrowser" || activeWidget === "tabbedEditor") {
+        _setWebBrowserAndEditorHeights(activeWidget, numOfWidgets, isPodHidden, editorWidget, browserWidget);
+      }
     } else if (numOfWidgets === 3) {
-        if (activeWidget === "webBrowser" || activeWidget === "tabbedEditor") {
-          _setWebBrowserAndEditorHeights(activeWidget, numOfWidgets, isPodHidden, editorWidget, browserWidget);
-        } else if (activeWidget === "pod") {
-            if (enablePod === true) {
-              // show pod
-              var podContainer = $("#" + podWidget.id);
-              podContainer.removeClass('multicolStepHidden');
-              // recalcuate brower/editor height
-              browserWidget.height =  browserWidgetHeight;
-              editorWidget.height = __calculateWidgetHeight(numOfWidgets, true, editorWidget.displayType);
-          }           
+      if (activeWidget === "webBrowser" || activeWidget === "tabbedEditor") {
+        _setWebBrowserAndEditorHeights(activeWidget, numOfWidgets, isPodHidden, editorWidget, browserWidget);
+      } else if (activeWidget === "pod") {
+        if (enablePod === true) {
+          // show pod
+          var podContainer = $("#" + podWidget.id);
+          podContainer.removeClass('multicolStepHidden');
+          // recalcuate brower/editor height
+          browserWidget.height = browserWidgetHeight;
+          editorWidget.height = __calculateWidgetHeight(numOfWidgets, true, editorWidget.displayType);
         }
+      }
     }
 
     // actual resize of widgets
     for (var i = 0; i < widgetInfo.length; i++) {
-        var widgetId = widgetInfo[i].id;
-        var widgetContainer = $("#" + widgetId);
-        widgetContainer.css("height", widgetInfo[i].height);
-        // Default 100% height is overridden under the cover during resizing.
-        // Has to explicit reset the height back to 100%.
-        if (widgetId.indexOf('tabbedEditor') !== -1) {
-          var teContainer = widgetContainer.find('.teContainer');
-          if (teContainer.length > 0) {
-            teContainer.css('height', '100%');
-          }
-          var editorContainer = widgetContainer.find('.editorContainer');
-          if (editorContainer.length > 0) {
-            editorContainer.css('height', '100%');
-          }
-        } else if (widgetId.indexOf('webBrowser') !== -1) {
-          var wb = widgetContainer.find('.wb');
-          if (wb.length > 0) {
-            wb.css('height', '100%');
-          }
+      var widgetId = widgetInfo[i].id;
+      var widgetContainer = $("#" + widgetId);
+      widgetContainer.css("height", widgetInfo[i].height);
+      // Default 100% height is overridden under the cover during resizing.
+      // Has to explicit reset the height back to 100%.
+      if (widgetId.indexOf('tabbedEditor') !== -1) {
+        var teContainer = widgetContainer.find('.teContainer');
+        if (teContainer.length > 0) {
+          teContainer.css('height', '100%');
         }
+        var editorContainer = widgetContainer.find('.editorContainer');
+        if (editorContainer.length > 0) {
+          editorContainer.css('height', '100%');
+        }
+      } else if (widgetId.indexOf('webBrowser') !== -1) {
+        var wb = widgetContainer.find('.wb');
+        if (wb.length > 0) {
+          wb.css('height', '100%');
+        }
+      }
     }
   }
 
@@ -733,6 +733,10 @@ var stepContent = (function() {
       }
   }
 
+  var getConfigWidgetHeights = function() {
+    return _mapWidgetsHeight;
+  }
+
   return {
     setSteps: setSteps,
     createStepHashIdentifier: __createStepHashIdentifier,
@@ -742,6 +746,7 @@ var stepContent = (function() {
     createGuideContents: createGuideContents,
     showStepWidgets: showStepWidgets,
     getStepWidgets: getStepWidgets,
-    resizeStepWidgets: resizeWidgets
+    resizeStepWidgets: resizeWidgets,
+    getConfigWidgetHeights: getConfigWidgetHeights
   };
 })();

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -493,7 +493,7 @@ var stepContent = (function() {
         // data-step attribute is used to look for content of an existing step in __hideContents
         // and __lookForExistingContents.
         var subContainerDivId = '<div id="' + subContainerId + '" data-step="' + step.name + '" class="subContainerDiv col-sm-12"></div>';
-        widget.id = subContainerDivId;
+        widget.id = subContainerId;
         var subContainer = $(subContainerDivId);
         if (isEnable === false) {
            subContainer.addClass('disableContainer');

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -327,7 +327,7 @@ var stepContent = (function() {
             widgetHeight = columnHeight - (wHeight + podHeight + (marginHeight * numOfWidgets)) + "px";
           }
         } else if (numOfWidgets === 2) {
-          widgetHeight = columnHeight - (wHeight + (marginHeight * numOfWidgets));
+          widgetHeight = columnHeight - (wHeight + (marginHeight * numOfWidgets)) + "px";
         }        
     } else {
       // Don't dictate the height in single column mode.
@@ -355,6 +355,41 @@ var stepContent = (function() {
     return widgetInfo;
   }
 
+  // For tabbed editor, the height could be taller than 400px if
+  // - number of widget is 3 and the pod is hidden at the moment
+  // - number of widget is 2
+  //
+  // For web browser, the height is either 300px when active or smaller when not active.
+  var _setWebBrowserAndEditorHeights = function(activeWidgetType, numOfWidgets, isPodHidden, editorWidget, browserWidget) {
+    var browserWidgetHeight = _mapWidgetsHeight["webBrowser"];
+    var editorWidgetMaxHeight = _mapWidgetsHeight["tabbedEditor"];
+
+    if (editorWidget !== undefined) {
+      if (activeWidgetType === "tabbedEditor") {
+        if (browserWidget !== undefined) {
+          // cal the browser height base on the remaining space
+          browserWidget.height = __calculateWidgetHeight(numOfWidgets, isPodHidden, browserWidget.displayType);
+        }
+
+        var browserHeight = parseInt(browserWidget.height.substring(0, browserWidget.height.indexOf("px")));
+        editorWidget.height = editorWidgetMaxHeight;  
+        if (browserHeight > 300) {
+          // browser should have a max height of 300; make editor taller
+          browserWidget.height = "300px";
+          var editorHeight = parseInt(editorWidget.height.substring(0, editorWidget.height.indexOf("px")));
+          editorWidget.height = editorHeight + (browserHeight - 300);
+        }         
+      } else {
+        if (browserWidget !== undefined) {
+          browserWidget.height = browserWidgetHeight;
+        }
+
+        // cal the editor height base on the remaining space         
+        editorWidget.height = __calculateWidgetHeight(numOfWidgets, isPodHidden, editorWidget.displayType);
+      }
+    }      
+  }
+
   var __getWidgetsInfoForStep = function(step) {
 
     var widgetsInfo = (step.content === undefined ? _defaultWidgets : __createWidgetInfo(step));
@@ -370,91 +405,52 @@ var stepContent = (function() {
     var browserWidget = __getInfoForWidget(widgetsInfo, "webBrowser");
     var editorWidget = __getInfoForWidget(widgetsInfo, "tabbedEditor");
     
-    // populate the widget object with height
-    if (numOfWidgets === 2) {
-        if (browserWidget !== undefined) {
-          browserWidget.height = browserWidgetHeight;
-        }
-        
-        if (editorWidget !== undefined) {
-          editorWidget.height = __calculateWidgetHeight(numOfWidgets, isPodHidden, editorWidget.displayType);
-        }
-    } else if (numOfWidgets === 3) {
-        if (podWidget !== undefined) {
-          podWidget.height = podWidgetHeight;
-          isPodHidden = podWidget.hidden;
-        }
-          
-        if (editorWidget !== undefined) {
-          if (editorWidget.active === true) {
-            if (browserWidget !== undefined) {
-              // cal the browser height base on the remaining space
-              browserWidget.height = __calculateWidgetHeight(numOfWidgets, isPodHidden, browserWidget.displayType);
-            }
-
-            editorWidget.height = editorWidgetMaxHeight;           
-          } else {
-            if (browserWidget !== undefined) {
-              browserWidget.height = browserWidgetHeight;
-            }
-
-            // cal the editor height base on the remaining space         
-            editorWidget.height = __calculateWidgetHeight(numOfWidgets, isPodHidden, editorWidget.displayType);
-          }
-        }      
+    if (podWidget !== undefined) {
+      podWidget.height = podWidgetHeight;
+      isPodHidden = podWidget.hidden;
     }
+    // populate the widget object with height
+    var activeWidgetType;
+    if (editorWidget.active) {
+      activeWidgetType = "tabbedEditor";
+    } else if (browserWidget.active) {
+      activeWidgetType = "webBrowser";
+    }
+    _setWebBrowserAndEditorHeights(activeWidgetType, numOfWidgets, isPodHidden, editorWidget, browserWidget);
     return widgetsInfo;
   }
 
   var resizeWidgets = function(widgetInfo, activeWidget, enablePod) {
-    if (inSingleColumnView())
-      return;
-
     var numOfWidgets = widgetInfo.length;
 
     var podWidget = __getInfoForWidget(widgetInfo, "pod");;
     var browserWidget = __getInfoForWidget(widgetInfo, "webBrowser");
     var editorWidget = __getInfoForWidget(widgetInfo, "tabbedEditor");
 
+    // set the current active widget to be used for resizing from single to multi column pane
+    _addActiveWidgetClass(widgetInfo, activeWidget);
+
+    if (inSingleColumnView())
+      return;
+
     var browserWidgetHeight = _mapWidgetsHeight["webBrowser"];
     var podWidgetHeight = _mapWidgetsHeight["pod"];
     var editorWidgetMaxHeight = _mapWidgetsHeight["tabbedEditor"];
 
+    // pod is always constant size
+    var isPodHidden = true;
+    if (podWidget !== undefined) {
+      podWidget.height = podWidgetHeight;
+      isPodHidden = podWidget.hidden;
+    } 
     // readjust the widgets height
     if (numOfWidgets === 2) {              
-        if (activeWidget === "webBrowser") {
-          if (browserWidget.height === browserWidgetHeight) {
-            return;
-          } else {
-            browserWidget.height = browserWidgetHeight;
-            editorWidget.height = __calculateWidgetHeight(numOfWidgets, false, editorWidget.displayType);
-          }
-        } else if (activeWidget === "tabbedEditor") {
-          if (editorWidget.height === editorWidgetMaxHeight) {
-            return;
-          } else {
-            browserWidget.height = __calculateWidgetHeight(numOfWidgets, false, browserWidget.displayType);;
-            editorWidget.height = editorWidgetMaxHeight;
-          }
-        }
+        if (activeWidget === "webBrowser" || activeWidget === "tabbedEditor") {
+          _setWebBrowserAndEditorHeights(activeWidget, numOfWidgets, isPodHidden, editorWidget, browserWidget);
+        } 
     } else if (numOfWidgets === 3) {
-        // pod is always constant size
-        podWidget.height = podWidgetHeight;
-
-        if (activeWidget === "webBrowser") {
-            if (browserWidget.height === browserWidgetHeight) {
-              return;
-            } else {
-              browserWidget.height = browserWidgetHeight;
-              editorWidget.height = __calculateWidgetHeight(numOfWidgets, false, editorWidget.displayType);
-            }
-        } else if (activeWidget === "tabbedEditor") {
-            if (editorWidget.height === editorWidgetMaxHeight) {
-              return;
-            } else {
-              browserWidget.height = __calculateWidgetHeight(numOfWidgets, false, browserWidget.displayType);
-              editorWidget.height =  editorWidgetMaxHeight;
-            }
+        if (activeWidget === "webBrowser" || activeWidget === "tabbedEditor") {
+          _setWebBrowserAndEditorHeights(activeWidget, numOfWidgets, isPodHidden, editorWidget, browserWidget);
         } else if (activeWidget === "pod") {
             if (enablePod === true) {
               // show pod
@@ -472,6 +468,36 @@ var stepContent = (function() {
         var widgetId = widgetInfo[i].id;
         var widgetContainer = $("#" + widgetId);
         widgetContainer.css("height", widgetInfo[i].height);
+        // Default 100% height is overridden under the cover during resizing.
+        // Has to explicit reset the height back to 100%.
+        if (widgetId.indexOf('tabbedEditor') !== -1) {
+          var teContainer = widgetContainer.find('.teContainer');
+          if (teContainer.length > 0) {
+            teContainer.css('height', '100%');
+          }
+          var editorContainer = widgetContainer.find('.editorContainer');
+          if (editorContainer.length > 0) {
+            editorContainer.css('height', '100%');
+          }
+        }
+    }
+  }
+
+  var _addActiveWidgetClass = function(widgetInfo, activeWidgetType) {
+    var activeWidget;
+    for (var i = 0; i < widgetInfo.length; i++) {
+      var widgetId = widgetInfo[i].id;
+      var widgetContainer = $("#" + widgetId);
+      if (widgetContainer.hasClass('activeWidget')) {
+        widgetContainer.removeClass('activeWidget');
+      }
+      if (widgetInfo[i].displayType === activeWidgetType) {
+        activeWidget = widgetContainer;
+      }
+    }
+
+    if (activeWidget) {
+      activeWidget.addClass('activeWidget');
     }
   }
 
@@ -574,6 +600,9 @@ var stepContent = (function() {
                   // dynamically setup height for each widget based on each step content    
                   var widgetHeight = widgetsObjInfo[index].height;
                   subContainer.css("height", widgetHeight);
+                }
+                if (content.active) {
+                  subContainer.addClass('activeWidget');
                 }
 
                 __createWidget(step.name, content, content.displayType, subContainer, displayTypeNum);

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -430,8 +430,14 @@ var stepContent = (function() {
     // set the current active widget to be used for resizing from single to multi column pane
     _addActiveWidgetClass(widgetInfo, activeWidget);
 
-    if (inSingleColumnView())
+    if (inSingleColumnView()) {
+      if (activeWidget === "pod" && enablePod === true) {
+          // show pod
+          var podContainer = $("#" + podWidget.id);
+          podContainer.removeClass('multicolStepHidden');
+      }
       return;
+    }
 
     var browserWidgetHeight = _mapWidgetsHeight["webBrowser"];
     var podWidgetHeight = _mapWidgetsHeight["pod"];
@@ -478,6 +484,11 @@ var stepContent = (function() {
           var editorContainer = widgetContainer.find('.editorContainer');
           if (editorContainer.length > 0) {
             editorContainer.css('height', '100%');
+          }
+        } else if (widgetId.indexOf('webBrowser') !== -1) {
+          var wb = widgetContainer.find('.wb');
+          if (wb.length > 0) {
+            wb.css('height', '100%');
           }
         }
     }


### PR DESCRIPTION
Changes include
+ refactor step-content to use a common function to drive the height calculation
+ add resize listener to adjust heights of the widgets in the code column
+ add activeWidget class to keep track of the current active widget. The activeWidget is used to size the widget height accordingly during resizing.
+ reset height to 100% to some inner containers that are given explicit height under the cover for some reason. 