### PR TITLE
Fix stepName issue

### DIFF
--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -126,7 +126,12 @@ var blueprint = (function(){
         // Update the selected TOC entry
         updateTOCHighlighting(id);  // In toc-multipane.js in openliberty.io
       }
-      stepContent.setCurrentStepName(id);
+      // look for the step name from the element with the matching id
+      var idElement = $("#" + id);
+      if (idElement.length > 0) {
+        var stepName = idElement.attr('data-step');
+        stepContent.setCurrentStepName(stepName);
+      }
     }
     
     if(window.innerWidth > twoColumnBreakpoint) {

--- a/js/interactive-guides/blueprint.js
+++ b/js/interactive-guides/blueprint.js
@@ -44,10 +44,9 @@ var blueprint = (function(){
             stepContent.setCurrentStepName(stepContent.getStepNameFromHash(hash.substring(1)));
           } else {
             // no hash -> at the top of the guide
-            var hash = "#Intro";
-            accessContentsFromHash(hash);
+            accessContentsFromHash(location.hash);
             // Show the widgets on the right for Intro step
-            stepContent.showStepWidgets(hash.substring(1));
+            stepContent.showStepWidgets(location.hash);
           }
 
           $(window).on('scroll', function(event) {
@@ -126,12 +125,7 @@ var blueprint = (function(){
         // Update the selected TOC entry
         updateTOCHighlighting(id);  // In toc-multipane.js in openliberty.io
       }
-      // look for the step name from the element with the matching id
-      var idElement = $("#" + id);
-      if (idElement.length > 0) {
-        var stepName = idElement.attr('data-step');
-        stepContent.setCurrentStepName(stepName);
-      }
+      stepContent.setCurrentStepName(stepContent.getStepNameFromHash(id));
     }
     
     if(window.innerWidth > twoColumnBreakpoint) {

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -11,7 +11,7 @@
 var stepContent = (function() {
   "use strict";
 
-  var currentStepName;
+  var currentStepName = ""; // Internal ID of the current step.  Not the hash ID.
   var _steps;
   var hashStepNames = {};   // Maps step's hash to its name.  This contains
                             // more entries than the _steps array because it also
@@ -86,8 +86,12 @@ var stepContent = (function() {
     return currentStepName;
   };
 
-  var setCurrentStepName = function(stepName) {    
-    currentStepName = stepName;   
+  /*
+    Tracks the current stepName.  NOTE: this should be the internal stepName for 
+                                        the step and NOT its hash ID.
+  */
+  var setCurrentStepName = function(stepName) {   
+    currentStepName = stepName;
   }
 
   /* 
@@ -196,23 +200,17 @@ var stepContent = (function() {
   };
 
   var __parseInstructionForActionTag = function(instruction) {
-    //console.log("instruction: ", instruction);
     if (instruction) {
       if ($.isArray(instruction)) {
         for (var i in instruction) {
-          //console.log("str ", desc);
           var instrStr = instruction[i];
-          //console.log("instr[" + i + "]", instrStr);
           var newInstrStr = utils.parseActionTag(instrStr);
-          //console.log("new instr ", newInstrStr);
           if (newInstrStr) {
             instruction[i] = newInstrStr;
           }
         }
       } else {
-        //console.log("single instr ");
         var newInstrStr = utils.parseActionTag(instruction);
-        //console.log("new instr ", newInstrStr);
         if (newInstrStr) {
           instruction = newInstrStr;
         }
@@ -734,27 +732,26 @@ var stepContent = (function() {
   /* 
    * Update widgets displayed on right-hand side of multipane layout for the specified id.
    * 
-   * id - the ID (hash value without the '#') for the given step.
+   * id - the step ID (hash value without the '#') for the given step.
    */
   var showStepWidgets = function(id) {
     // Find the stepName based on the ID
     var stepName = getStepNameFromHash(id);
-    if (window.innerWidth >= twoColumnBreakpoint) {      
+    if (window.innerWidth >= twoColumnBreakpoint) {
       // #codeColumn is showing.   Only display applicable widgets for the step.
       $('.multicolStepShown').removeClass('multicolStepShown').addClass('multicolStepHidden');
 
-      // stepName is "" when srollTop displays guide header, or guide meta.
+      // stepName is "" when srollTop displays guide header, or #guide_meta.
       if (stepName === "") {
-        // set stepName to Intro when at the top of the guide to display the widgets
+        // Set stepName to Intro when at the top of the guide to display the widgets
+        // from the first section.
         stepName = "Intro";
       }
-      if (stepName) {
-        // Find the .stepWidgetContainer holding the widgets for the specified step.
-        var $selectedStepContainer =  $('.stepWidgetContainer[data-step=' + stepName + ']');
-        $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');
-      }
+
+      // Find the .stepWidgetContainer holding the widgets for the specified step.
+      var $selectedStepContainer =  $('.stepWidgetContainer[data-step=' + stepName + ']');
+      $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');
     } 
-    setCurrentStepName(stepName);
   };
 
   var __createWidget = function(stepName, content, displayType, subContainer, displayTypeNum) {

--- a/js/interactive-guides/step-content.js
+++ b/js/interactive-guides/step-content.js
@@ -737,10 +737,9 @@ var stepContent = (function() {
    * id - the ID (hash value without the '#') for the given step.
    */
   var showStepWidgets = function(id) {
-    if (window.innerWidth >= twoColumnBreakpoint) {
-      // Find the stepName based on the ID
-      var stepName = getStepNameFromHash(id);
-      
+    // Find the stepName based on the ID
+    var stepName = getStepNameFromHash(id);
+    if (window.innerWidth >= twoColumnBreakpoint) {      
       // #codeColumn is showing.   Only display applicable widgets for the step.
       $('.multicolStepShown').removeClass('multicolStepShown').addClass('multicolStepHidden');
 
@@ -755,6 +754,7 @@ var stepContent = (function() {
         $selectedStepContainer.removeClass('multicolStepHidden').addClass('multicolStepShown');
       }
     } 
+    setCurrentStepName(stepName);
   };
 
   var __createWidget = function(stepName, content, displayType, subContainer, displayTypeNum) {


### PR DESCRIPTION
This PR is to fix stepName issue when calling stepContent.getCurrentStepName in single column view. Even with the fix, the current step name may be pointing to the previous step which happens to occupy more space in the current viewport. 

Steven knows about the problem if my explanation is not clear enough.