### PR TITLE
Do not let contents extend beyond pod

### DIFF
--- a/css/interactive-guides/pod.scss
+++ b/css/interactive-guides/pod.scss
@@ -10,6 +10,8 @@
  *******************************************************************************/
 
 .podContainer {
+  overflow: hidden;
+  
   @media (min-width: 1170px) {
     border: 1px solid #c8d6fb;
     border-radius: 4px 4px 4px 4px;


### PR DESCRIPTION
Set pod content to overflow:hidden so content extending beyond borders is not displayed.