### PR TITLE
Focus tab in saveTabbedEditor

### DIFF
--- a/js/interactive-guides/modules/content-manager.js
+++ b/js/interactive-guides/modules/content-manager.js
@@ -669,6 +669,9 @@ var contentManager = (function() {
         if (tabbedEditor) {
             var teditor = tabbedEditor.getEditorByFileName(fileName);
             if (teditor) {
+                // Put the correct Tab into focus prior to processing save.
+                contentManager.focusTabbedEditorByName(stepName, fileName);
+
                 teditor.saveEditor();
             }
         }

--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 var editor = (function() {
-    var __editors = {}; // ToDo: __editors is no longer needed with the new changes
 
     var editorType = function(container, stepName, content) {
         var deferred = new $.Deferred();
@@ -340,8 +339,6 @@ var editor = (function() {
             __addRedoOnClickListener(thisEditor, redoButton);
             __addSaveOnClickListener(thisEditor, runButton);
         }
-
-        __editors[stepName] = thisEditor.editor;
     };
 
     var __adjustReadOnlyLines = function(readonlyLinesArray) {

--- a/js/interactive-guides/modules/tabbed-editor.js
+++ b/js/interactive-guides/modules/tabbed-editor.js
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 var tabbedEditor = (function() {
-    var __editors = [];
 
     var tabbedEditorType = function(container, stepName, content) {
         /**

--- a/js/interactive-guides/modules/web-browser.js
+++ b/js/interactive-guides/modules/web-browser.js
@@ -67,7 +67,6 @@ var webBrowser = (function(){
       var file =  extension === 'html' || extension === 'htm' ? true: false;
       if (file) {
         var fileLocation = content;
-        var $iframe = $webContentElement.find('iframe');
         $iframe.attr('src', fileLocation);
 
         /* Do we need to try to see if the file is available?


### PR DESCRIPTION
When processing via instructions a 'Save' action for one of the tabs in a tabbedEditor, make sure that the tab containing the file is focused.

Also removed some dead code in files:

- editor.js and tabbed-editor.js
`__editors` is no longer needed.

- web-browser.js
duplicate code...see line 59 above it.
