### PR TITLE
Remove editorHeight setting from Editor JSON.

### DIFF
--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -227,12 +227,6 @@ var editor = (function() {
                         container.find('.editorContainer').attr("aria-label", content.fileName + " editor");
                         container.find('.editorFileName').text(content.fileName);
                         thisEditor.fileName = content.fileName;              
-
-                        if (content.editorHeight !== undefined) {             
-                            container.find(".editorContainer").css({
-                                "height": content.editorHeight
-                            });
-                        }
                     }
                     var editor = container.find('.codeeditor');
                     var id = container[0].id + "-codeeditor";


### PR DESCRIPTION
Remove the code that processed the editorHeight setting in the JSON for the Editor widget as it is no longer valid to set the height there.

If the editor will not be using the tabbedEditor height set in the "configWidgets" stanza of the JSON file, then a different height can be specified for the tabbedEditor using plain "height". Setting "editorHeight" on an individual editor within the tabbedEditor is no longer honored.