### PR TITLE
Disable click events on "disabled" button

### DIFF
--- a/css/interactive-guides/web-browser.scss
+++ b/css/interactive-guides/web-browser.scss
@@ -49,6 +49,7 @@
 
 .wbNavButtonDisabled {
     opacity: 0.5;
+    pointer-events: none;
 }
 
 .wbNavButtonActive:hover {


### PR DESCRIPTION
Disabled refresh button in the sample browser was still selectable.  In the guides, on any of the pages where the browser is greyed out (like on the What you'll learn step), you could click on the refresh button and see the sample browser page update.  

Update the CSS to prevent the click from processing on a greyed out refresh button.   NOTE:  the refresh button is not really a button but a span element behaving as one.  That is why marking it as 'disabled' would not work since it is really not a form element. 