### PR TITLE
 Editor: default to "Run" button 

### DIFF
--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -243,6 +243,8 @@ var editor = (function() {
     };
 
     var __createEditor = function(thisEditor, id, container, stepName, content) {
+        console.log(stepName);
+        console.log(content.save);
         var isReadOnly = false;
         var markText = [];
         var markTextWritable = [];
@@ -306,7 +308,7 @@ var editor = (function() {
 
         thisEditor.codeEditor = container.find(".codeeditor");
 
-        if ((content.save === false || content.save === "false")) {
+        if ((content.save === undefined || content.save === false || content.save === "false")) {
             saveButton.addClass("hidden");
         } else if ((content.save === true || content.save === "true")) {
             runButton.addClass("hidden");

--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -243,8 +243,6 @@ var editor = (function() {
     };
 
     var __createEditor = function(thisEditor, id, container, stepName, content) {
-        console.log(stepName);
-        console.log(content.save);
         var isReadOnly = false;
         var markText = [];
         var markTextWritable = [];

--- a/js/interactive-guides/modules/tabbed-editor.js
+++ b/js/interactive-guides/modules/tabbed-editor.js
@@ -51,8 +51,7 @@ var tabbedEditor = (function() {
          *                               "      <feature>cdi-1.2</feature>",
          *                               "   </featureManager>",
          *                               "</server>"
-         *                             ],
-         *                             "save": true
+         *                             ]
          *                         },
          *                         {
          *                             "displayType":"fileEditor",


### PR DESCRIPTION
In the multipane design, it was decided that all editors should have the 'Run' button instead of the 'Save' button.  Update editor.js to default to the 'Run' button.

Also updated the comment in tabbed-editor.js that shows suggested JSON for an editor within a tabbed-editor.