### PR TITLE
Add CSS style to highlight new text added in instruction button

### DIFF
--- a/css/interactive-guides/main.scss
+++ b/css/interactive-guides/main.scss
@@ -97,6 +97,11 @@ action:focus {
   color:#1b1c34;
 }
 
+.actionAddedText {    // Text added to an action button (built on from a previous button's text)
+  color: #1F242F;
+  font-weight: 500;  // Bold this text
+}
+
 instruction {
   width: 100%;
   margin-bottom: 25px;


### PR DESCRIPTION
Added class .actionAddedText to main.scss which defines a dark blue color and sets the font weight to bolded (500).

```
.actionAddedText {    
  color: #1F242F;
  font-weight: 500;  
}
```

To use, add this class to a `<span>` surrounding the text that was added.  For example:
`....failureRatio=0.5, delay=5000, <span class='actionAddedText'>successThreshold=2</span>)</action>`

This will cause the text within the `<span>` tag to be highlighted to show which part of the action button was updated.

![image](https://user-images.githubusercontent.com/29490139/51138305-6b440100-1806-11e9-954c-be5d3a036967.png)
