### PR TITLE
Support for individual error in each editor

### DIFF
--- a/js/interactive-guides/modules/content-manager.js
+++ b/js/interactive-guides/modules/content-manager.js
@@ -601,6 +601,22 @@ var contentManager = (function() {
         }
     };
 
+    /** Scroll the editor content into view with specified FileEditor instance within a TabbedEditor
+     * @param {String} stepName - name of step where FileEditor is located
+     * @param {String} fileName - file name of editor within TabbedEditor   
+     * @param {Integer} lineNumber - the line number in the editor to scroll to view
+     * @param {Integer} instanceNumber - (optional) zero-indexed instance number of FileEditor
+     */
+    var scrollTabbedEditorToView = function(stepName, fileName, lineNumber, instanceNumber) {
+        var tabbedEditor = __getTabbedEditorInstance(stepName, instanceNumber);
+        if (tabbedEditor) {
+            var teditor = tabbedEditor.getEditorByFileName(fileName);
+            if (teditor) {
+                teditor.scrollToLine(lineNumber);
+            }
+        }
+    };
+
     /** Insert content before a certain line in a specified FileEditor instance
      *  within a TabbedEditor.
      * @param {String} stepName - name of step where TabbedEditor is located
@@ -941,6 +957,7 @@ var contentManager = (function() {
         saveTabbedEditor: saveTabbedEditor,
         markTabbedEditorReadOnlyLines: markTabbedEditorReadOnlyLines,
         resizeTabbedEditor: resizeTabbedEditor,
+        scrollTabbedEditorToView: scrollTabbedEditorToView,
 
         setInstructions: setInstructions,
         checkIfInstructionsForStep: checkIfInstructionsForStep,

--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -209,6 +209,11 @@ var editor = (function() {
                 }, 4000);
             }
         },
+        
+        scrollToLine: function(i) {
+            // scroll the editor content to the specified line i
+            this.editor.scrollIntoView({line: i, ch: 0});
+        }
 
     };
 

--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -102,7 +102,6 @@ var editor = (function() {
             } 
         },
         addSaveListener: function(callback) {
-            //console.log("saveListener callback", callback);
             this.saveListenerCallback = callback;
         },
         addContentChangeListener: function(callback) {
@@ -146,8 +145,8 @@ var editor = (function() {
         closeEditorErrorBox: function() {
             if (this.alertFrame.length) {
                 this.alertFrame.addClass("hidden");
-                // recalculate the height when alert pane is closed
-                this.codeEditor.css("height", 'calc(100% - 34px)');
+                // reset the height when alert pane is closed
+                this.codeEditor.find('.CodeMirror').css("height", '100%');
             }
         },
         createErrorLinkForCallBack: function(isSave, correctErrorCallback) {
@@ -213,12 +212,14 @@ var editor = (function() {
         scrollToLine: function(i) {
             // scroll the editor content to the specified line i
             this.editor.scrollIntoView({line: i, ch: 0});
-        }
+        },
 
+        resizeContent: function() {
+            __resizeAlertFrame(this);
+        }
     };
 
     var __loadAndCreate = function(thisEditor, container, stepName, content) {
-            //console.log("using ajax to load editor.html", container);
             var deferred = new $.Deferred();
             $.ajax({
                 context: thisEditor,
@@ -240,7 +241,6 @@ var editor = (function() {
                     deferred.resolve(thisEditor);
                 },
                 error: function (result) {
-                    //console.error("Could not load the edittor.html");
                     deferred.resolve(thisEditor);
                 }
             });
@@ -283,7 +283,6 @@ var editor = (function() {
             if ($.isArray(content.preload)) {
                 preloadEditorContent = content.preload.join("\n");
             }
-            //console.log("formatted preloadEditorContent", preloadEditorContent);
             thisEditor.editor.setValue(preloadEditorContent);
             thisEditor.editor.contentValue = preloadEditorContent;
         }
@@ -357,13 +356,9 @@ var editor = (function() {
 
             if ($.isNumeric(readonlyLines.from)) {
                 fromLine = parseInt(readonlyLines.from) - 2;
-            } else {
-                //console.log("invalid from line", readonlyLines.from);
             }
             if ($.isNumeric(readonlyLines.to)) {
                 toLine = parseInt(readonlyLines.to) - 1;
-            } else {
-                //console.log("invalid to line", readonlyLines.to);
             }
             if (fromLine !== undefined && toLine !== undefined) {
                 markText.push({
@@ -451,8 +446,6 @@ var editor = (function() {
         var idError = "error_" + thisEditor.stepName + "_" + thisEditor.fileName; //added filenName to id to avoid duplicate ids
        
         var codeEditor = thisEditor.codeEditor;
-        // when alert pane is show, recalculate the editor height 100% - 68px (editor button frame height + alert frame height)
-        codeEditor.css("height", 'calc(100% - 68px)');
         
         // With the tabbedEditor, use the cached alertFrame.
         var editorError = thisEditor.alertFrame;
@@ -491,6 +484,7 @@ var editor = (function() {
             editorError.append(closeButton);
         }
         editorError.append('</span>');
+        __resizeAlertFrame(thisEditor);
     };
 
     var __correctEditorError = function(thisEditor, isSave, correctErrorCallback) {
@@ -641,6 +635,21 @@ var editor = (function() {
     var __create = function(container, stepName, content) {
         return new editorType(container, stepName, content);
     };
+
+    var __resizeAlertFrame = function(thisEditor) {
+        var codeEditor = thisEditor.codeEditor;
+        var editorError = thisEditor.alertFrame;
+
+        if (editorError.is(':visible')) {
+            // reset the height to fit the content
+            editorError.css('height', 'auto');
+            var errorText = editorError.find('span');
+            // change display so that the close button will position correctly
+            errorText.css('display', "inline-block");
+            // calculate the remaining height for code mirror when alert/error is displayed
+            codeEditor.find('.CodeMirror').css("height", 'calc(100% - ' + editorError.outerHeight() + 'px)');
+        }
+    }
 
     return {
         //getEditor: __getEditor

--- a/js/interactive-guides/modules/tabbed-editor.js
+++ b/js/interactive-guides/modules/tabbed-editor.js
@@ -151,6 +151,12 @@ var tabbedEditor = (function() {
                 thisTabbedEditor.$active.parent().css(thisTabbedEditor.cssWidthValue, thisTabbedEditor.activeTabSize);  // <li> element
                 thisTabbedEditor.$content.show();
 
+                if (activeTabChanged) {
+                    // call the editor to adjust the content height if alert is shown
+                    var editor = thisTabbedEditor.getEditorByFileName(newActiveFileName);
+                    editor.resizeContent();
+                }
+
                 if (activeTabChanged && thisTabbedEditor.activeTabChangeCallback) {
                     thisTabbedEditor.activeTabChangeCallback(newActiveFileName);
                 }


### PR DESCRIPTION
Fix height adjustment on the correct element when alert/error is displayed and add codes to adjust the height of the content in the editor when tab is changed in the tabbed editor