### PR TITLE
Remove setting the pod height

### DIFF
--- a/js/interactive-guides/modules/pod.js
+++ b/js/interactive-guides/modules/pod.js
@@ -92,13 +92,6 @@ var pod = (function(){
           container.append($(result));
           thisPod.contentRootElement = container.find('.podContainer').first();          
 
-          // set the pod height for the right column
-          if (content.height !== undefined) {
-            container.find(".podContainer").css({
-              "height": content.height
-            });
-          }
-
           // fill in contents
           thisPod.setContent(content.content, content.callback);
           deferred.resolve(thisPod);


### PR DESCRIPTION
With the new multiPane design, the height of each widget is controlled by the container element. Remove the code to set the podContainer height.