### PR TITLE
Indicate error found in a file

### DIFF
--- a/css/interactive-guides/main.scss
+++ b/css/interactive-guides/main.scss
@@ -102,6 +102,19 @@ action:focus {
   font-weight: 500;  // Bold this text
 }
 
+codeblock {
+  letter-spacing: 0;
+  color: #5e6b8d;
+  background: #f1f4fe;
+  border: 1px solid #C8D5FF;
+  padding: 9px 12px;
+  margin: 10px 10px 10px 0px;
+  display: inline-block;
+  white-space: pre-wrap;
+  max-width: 600px;
+  min-width: 280px;
+}
+
 instruction {
   width: 100%;
   margin-bottom: 25px;

--- a/css/interactive-guides/tabbed-editor.scss
+++ b/css/interactive-guides/tabbed-editor.scss
@@ -28,7 +28,7 @@
     }
 
     &.active {
-        background-color: #c7ccd9;
+        background-color: #c7ccd9 !important;
         color: #3f465a !important;
     }
 
@@ -37,7 +37,7 @@
     }
 
     &.errorInTab {
-        background-color: #f2dede !important;
+        background-color: #f2dede;
         color: #a94442 !important;
     }
 }

--- a/css/interactive-guides/tabbed-editor.scss
+++ b/css/interactive-guides/tabbed-editor.scss
@@ -35,6 +35,11 @@
     &:hover {
         background-color: #D6DAE6;
     }
+
+    &.errorInTab {
+        background-color: #f2dede !important;
+        color: #a94442 !important;
+    }
 }
 
 .teTabContent {

--- a/js/interactive-guides/modules/editor.js
+++ b/js/interactive-guides/modules/editor.js
@@ -142,11 +142,15 @@ var editor = (function() {
         markEditorReadOnly: function() {
             __markEditorReadOnly(this);
         },
-        closeEditorErrorBox: function() {
+        closeEditorErrorBox: function(isClearErrorInTabbedEditor) {
             if (this.alertFrame.length) {
                 this.alertFrame.addClass("hidden");
                 // reset the height when alert pane is closed
                 this.codeEditor.find('.CodeMirror').css("height", '100%');
+            }
+            // By default reset the tab with no error when closing the error box in the editor
+            if ((isClearErrorInTabbedEditor === undefined || isClearErrorInTabbedEditor) && this.tabbedEditor) {
+                this.tabbedEditor.resetEditorTabWithNoErrorByFileName(this.fileName);
             }
         },
         createErrorLinkForCallBack: function(isSave, correctErrorCallback) {
@@ -161,7 +165,7 @@ var editor = (function() {
             var errorMsg = messages.editorReadonlyAlert;
             __createErrorAlertPane(this, 'alert-warning', false, false, errorMsg);
         },
-        createCustomErrorMessage: function(errorMsg){
+        createCustomErrorMessage: function(errorMsg) {
             __createErrorAlertPane(this, 'alert-danger', false, true, errorMsg);
         },
         createCustomAlertMessage: function(alertMsg) {
@@ -177,6 +181,9 @@ var editor = (function() {
             // parameter.
             var codeUpdatedElement = this.editorButtonFrame.find(".codeUpdated");
             if (codeUpdatedElement.length > 0) {
+                // reset the tab to no error when code updated is called
+                this.tabbedEditor.resetEditorTabWithNoErrorByFileName(this.fileName);
+
                 codeUpdatedElement.removeClass('codeUpdatedHidden');
                 var animationClass = 'codeUpdatedToFadeOut';
                 if (isFadeInFadeOut) {
@@ -220,6 +227,10 @@ var editor = (function() {
 
         resizeContent: function() {
             __resizeAlertFrame(this);
+        },
+
+        setTabbedEditor: function(tabbedEditor) {
+            this.tabbedEditor = tabbedEditor;
         }
     };
 
@@ -477,7 +488,7 @@ var editor = (function() {
             var handleOnClickClose = function (event) {
                 event.preventDefault();
                 event.stopPropagation();
-                thisEditor.closeEditorErrorBox();
+                thisEditor.closeEditorErrorBox(false);
                 editorError.attr('tabindex', '-1');
             };
             var bkgcolor = "";
@@ -489,6 +500,10 @@ var editor = (function() {
         }
         editorError.append('</span>');
         __resizeAlertFrame(thisEditor);
+
+        if (alertClass === "alert-danger" && this.tabbedEditor) {
+            thisEditor.tabbedEditor.markEditorTabWithErrorByFileName(thisEditor.fileName);
+        }
     };
 
     var __correctEditorError = function(thisEditor, isSave, correctErrorCallback) {

--- a/js/interactive-guides/modules/tabbed-editor.js
+++ b/js/interactive-guides/modules/tabbed-editor.js
@@ -171,6 +171,7 @@ var tabbedEditor = (function() {
                 // Remove the editor's file name that appears above a single editor
                 $tabContent.find('.editorFileName').parent().remove();
                 thisTabbedEditor.editorList[editorName] = newEditor;
+                newEditor.setTabbedEditor(thisTabbedEditor);
             });
         },
 
@@ -310,7 +311,19 @@ var tabbedEditor = (function() {
                     editorContainer.css('height', newHeight);  
                 }                
             } 
-        }     
+        },
+ 
+        markEditorTabWithErrorByFileName: function(fileName) {
+            var tab = this.findEditorTabByFileName(fileName);
+            tab.addClass('errorInTab');
+            tab.attr("aria-label", 'Error in ' + fileName);
+        },
+
+        resetEditorTabWithNoErrorByFileName: function(fileName) {
+            var tab = this.findEditorTabByFileName(fileName);
+            tab.removeClass('errorInTab');
+            tab.attr("aria-label", fileName);
+        }
     };
 
     var __loadAndCreate = function(thisTabbedEditor, container, stepName, content) {


### PR DESCRIPTION
To indicate error found in a file, the tab will be displayed in the same red color as the error and the aria-label will be updated to indicate "Error in \<file name\>"

![image](https://user-images.githubusercontent.com/25039033/53030757-157bfd80-3431-11e9-8805-7f92f70b3061.png)
