### PR TITLE
set width to code block

### DIFF
--- a/css/interactive-guides/main.scss
+++ b/css/interactive-guides/main.scss
@@ -113,6 +113,7 @@ codeblock {
   white-space: pre-wrap;
   max-width: 600px;
   min-width: 280px;
+  width: 100%;
 }
 
 instruction {
@@ -148,6 +149,7 @@ instruction.unavailable {
   letter-spacing:0;
   line-height:24px;
   text-align:left;
+  width: 100%;
 }
 
 .stepWidgetContainer {


### PR DESCRIPTION
If a code block contains a long piece of code without any blank in it, it could cause the code block to overflow.

![image](https://user-images.githubusercontent.com/25039033/63606053-dcb21200-c594-11e9-8a90-b142716b1ef2.png)
