### PR TITLE
Fix accessibility issues with the Global eBank Welcome page

### DIFF
--- a/css/interactive-guides/bankApp.css
+++ b/css/interactive-guides/bankApp.css
@@ -47,7 +47,7 @@ body {
 .bankHeading {
     font-weight: 500;
     font-size: 16px;
-    color: #5E6B8D;
+    color: #5b6888;  /*#5E6B8D;*/
     letter-spacing: 0;
     text-align: left;
     padding: 9px 0px 9px 18px;
@@ -89,11 +89,11 @@ body {
     flex-wrap: nowrap;
     flex-direction: column;
     justify-content: center;
-    margin: 24px 24px 0; 
+    margin: 24px 24px 0;
     flex-grow: 1;
     overflow: hidden;
 }
-  
+
 .flexWarningContainer > div {
     text-align: center;
     line-height: 24px;
@@ -187,7 +187,7 @@ body {
 
 @media (max-width: 620px) {
     .welcomeTextWrapper {
-        justify-content: center;  /* need to adjust the alignment to the center because the image 
+        justify-content: center;  /* need to adjust the alignment to the center because the image
                                      shrinks causing mis-alignment */
     }
 }

--- a/html/interactive-guides/bankApp-welcome.html
+++ b/html/interactive-guides/bankApp-welcome.html
@@ -1,22 +1,23 @@
 <!DOCTYPE html>
 <!--
-  Copyright (c) 2018 IBM Corporation and others.
+  Copyright (c) 2018, 2021 IBM Corporation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/legal/epl-v10.html
- 
+
   Contributors:
       IBM Corporation - initial API and implementation
 -->
-<html style="height: 100%;">
+<html style="height: 100%;" lang="en">
 
 <head>
+    <title>Welcome to Global eBank</title>
     <link href="https://fonts.googleapis.com/css?family=Asap" rel="stylesheet">
     <link rel="stylesheet" href="/guides/iguides-common/css/interactive-guides/bankApp.css">
     <script type="text/javascript">
         var script = document.createElement('script');
- 
+
         script.onload = function() {
             var guideRootDir = "/guides/iguides-common/js/interactive-guides/nls/"
             retrieveExternalizedStrings(guideRootDir);
@@ -27,6 +28,7 @@
 </head>
 
 <body style="height: 100%;">
+  <main aria-labelledby="welcome">
     <div class="bankHeadingBlockFlexContainer">
         <div class="bankHeading">Global eBank</div>
         <span>
@@ -36,10 +38,10 @@
     </div>
     <div id="welcome">
         <div class="flexWelcomeContainer">
-            <figure>
+            <figure aria-labelledby="bankName">
                 <img src="/guides/iguides-common/img/interactive-guides/bank-logo.svg" data-externalizedAlt="BANK_LOGO">
             </figure>
-            <div class="welcomeTextWrapper">
+            <div id="bankName" class="welcomeTextWrapper">
                 <div class="welcomeBorderWrapper">
                     <p data-externalizedString="WELCOME"></p>
                     <div class="welcomeLine"></div>
@@ -50,5 +52,6 @@
             </div>
         </div>
     </div>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
Copied from https://github.com/OpenLiberty/iguides-common/pull/344

Within the interactive guides, the Global eBank Welcome page had a few errors found when running the Accessibility Checker against the guides.   Refer to Issue #343 for more information.

Added the following:
1) Changed the color of the text 'Global eBank' in the blue header of the page to meet contrast ratio guidelines.
2) Added a default `lang` to the HTML
3) Added a `<title>` to the HTML header
4) Added a `<main>` section to the HTML content
5) Figure needed to point to a label, so added `aria-labelledby` to point to one.